### PR TITLE
Change OpenAPI embedding model to new generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Initially, only a minimal subset of all of Chroma's interface is implemented or 
 - [X] Zero dependencies on third party libraries
 - [X] Concurrent processing (when adding and querying documents)
 - Embedding creators:
-  - [X] [OpenAI ada v2](https://platform.openai.com/docs/guides/embeddings/embedding-models) (default)
+  - [X] [OpenAI text-embedding-3-small](https://platform.openai.com/docs/guides/embeddings/embedding-models) (default)
   - [X] Bring your own
   - [ ] [Mistral (API)](https://docs.mistral.ai/api/#operation/createEmbedding)
   - [ ] [ollama](https://ollama.ai/)

--- a/client.go
+++ b/client.go
@@ -6,8 +6,8 @@ import (
 )
 
 // EmbeddingFunc is a function that creates embeddings for a given document.
-// chromem-go will use OpenAI`s ada v2 model by default, but you can provide your
-// own function, using any model you like.
+// chromem-go will use OpenAI`s "text-embedding-3-small" model by default,
+// but you can provide your own function, using any model you like.
 type EmbeddingFunc func(ctx context.Context, document string) ([]float32, error)
 
 // DB is the chromem-go database. It holds collections, which hold documents.

--- a/embedding.go
+++ b/embedding.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	baseURLOpenAI        = "https://api.openai.com/v1"
-	embeddingModelOpenAI = "text-embedding-ada-002"
+	baseURLOpenAI              = "https://api.openai.com/v1"
+	embeddingModelOpenAI3Small = "text-embedding-3-small"
 )
 
 type openAIResponse struct {
@@ -22,18 +22,18 @@ type openAIResponse struct {
 	} `json:"data"`
 }
 
-// CreateEmbeddingsDefault returns a function that creates embeddings for a document using using
-// OpenAI`s ada v2 model via their API.
-// The model supports a maximum document length of 8192 tokens.
+// CreateEmbeddingsDefault returns a function that creates embeddings for a document
+// using OpenAI`s "text-embedding-3-small" model via their API.
+// The model supports a maximum document length of 8191 tokens.
 // The API key is read from the environment variable "OPENAI_API_KEY".
 func CreateEmbeddingsDefault() EmbeddingFunc {
 	apiKey := os.Getenv("OPENAI_API_KEY")
 	return CreateEmbeddingsOpenAI(apiKey)
 }
 
-// CreateEmbeddingsOpenAI returns a function that creates the embeddings for a document
-// using OpenAI`s ada v2 model via their API.
-// The model supports a maximum document length of 8192 tokens.
+// CreateEmbeddingsDefault returns a function that creates embeddings for a document
+// using OpenAI`s "text-embedding-3-small" model via their API.
+// The model supports a maximum document length of 8191 tokens.
 func CreateEmbeddingsOpenAI(apiKey string) EmbeddingFunc {
 	// We don't set a default timeout here, although it's usually a good idea.
 	// In our case though, the library user can set the timeout on the context,
@@ -44,7 +44,7 @@ func CreateEmbeddingsOpenAI(apiKey string) EmbeddingFunc {
 		// Prepare the request body.
 		reqBody, err := json.Marshal(map[string]string{
 			"input": document,
-			"model": embeddingModelOpenAI,
+			"model": embeddingModelOpenAI3Small,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("couldn't marshal request body: %w", err)


### PR DESCRIPTION
From text-embedding-ada-002 to text-embedding-3-small

See their blob post for details: https://openai.com/blog/new-embedding-models-and-api-updates

There's also the `*-large` model, but for the purpose of chromem-go (embedded, local, simple) the much cheaper model seems more appropriate.