### PR TITLE
Stop exporting Collection.Metadata

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -12,7 +12,7 @@ import (
 // that don't have embeddings yet.
 type Collection struct {
 	Name     string
-	Metadata map[string]string
+	metadata map[string]string
 
 	documents     map[string]*document
 	documentsLock sync.RWMutex
@@ -25,7 +25,7 @@ type Collection struct {
 func newCollection(name string, metadata map[string]string, embed EmbeddingFunc) *Collection {
 	return &Collection{
 		Name:     name,
-		Metadata: metadata,
+		metadata: metadata,
 
 		documents: make(map[string]*document),
 

--- a/db.go
+++ b/db.go
@@ -80,8 +80,8 @@ func (c *DB) GetCollection(name string) *Collection {
 		return nil
 	}
 
-	newMetadata := make(map[string]string, len(orig.Metadata))
-	for k, v := range orig.Metadata {
+	newMetadata := make(map[string]string, len(orig.metadata))
+	for k, v := range orig.metadata {
 		newMetadata[k] = v
 	}
 
@@ -94,7 +94,7 @@ func (c *DB) GetCollection(name string) *Collection {
 
 	return &Collection{
 		Name:     orig.Name,
-		Metadata: newMetadata,
+		metadata: newMetadata,
 
 		documents: make(map[string]*document, len(orig.documents)),
 

--- a/db_test.go
+++ b/db_test.go
@@ -34,14 +34,17 @@ func TestDB_ListCollections(t *testing.T) {
 	if c.Name != name {
 		t.Error("expected name", name, "got", c.Name)
 	}
-	if len(c.Metadata) != 1 {
-		t.Error("expected 1 metadata, got", len(c.Metadata))
-	}
-	if c.Metadata["foo"] != "bar" {
-		t.Error("expected metadata", metadata, "got", c.Metadata)
-	}
+	// TODO: Check metadata when it's accessible (e.g. with GetMetadata())
+	// if len(c.Metadata) != 1 {
+	// 	t.Error("expected 1 metadata, got", len(c.Metadata))
+	// }
+	// if c.Metadata["foo"] != "bar" {
+	// 	t.Error("expected metadata", metadata, "got", c.Metadata)
+	// }
+	// TODO: Same for documents and EmbeddingFunc
 
-	// And it should be a copy
+	// And it should be a copy. Adding a value here should not reflect on the DB's
+	// collection.
 	res["foo"] = &chromem.Collection{}
 	if len(db.ListCollections()) != 1 {
 		t.Error("expected 1 collection, got", len(db.ListCollections()))
@@ -68,12 +71,13 @@ func TestDB_GetCollection(t *testing.T) {
 	if c.Name != name {
 		t.Error("expected name", name, "got", c.Name)
 	}
-	if len(c.Metadata) != 1 {
-		t.Error("expected 1 metadata, got", len(c.Metadata))
-	}
-	if c.Metadata["foo"] != "bar" {
-		t.Error("expected metadata", metadata, "got", c.Metadata)
-	}
+	// TODO: Check metadata when it's accessible (e.g. with GetMetadata())
+	// if len(c.Metadata) != 1 {
+	// 	t.Error("expected 1 metadata, got", len(c.Metadata))
+	// }
+	// if c.Metadata["foo"] != "bar" {
+	// 	t.Error("expected metadata", metadata, "got", c.Metadata)
+	// }
 	// TODO: Check documents content as soon as we have access to them
 	// TODO: Same for the EmbeddingFunc
 	// TODO: Check documents map being a copy as soon as we have access to it


### PR DESCRIPTION
Prevent users to directly modify the map while concurrent operations (e.g. `Query()`) range over it, causing data races.