### PR TITLE
Improve query sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 vNext
 -----
 
-In this release the main feature is query performance improvement (4x faster, 99% fewer memory allocations). There's also a new code example for semantic search across 5,000 arXiv papers.
+In this release the main feature is query performance improvement (5x faster, 99% fewer memory allocations). There's also a new code example for semantic search across 5,000 arXiv papers.
 
 ### Added
 
@@ -18,7 +18,7 @@ In this release the main feature is query performance improvement (4x faster, 99
 ### Improved
 
 - Changed the example link target to directory instead of `main.go` file (PR [#43](https://github.com/philippgille/chromem-go/pull/43))
-- Improved query performance (4x faster, 99% fewer memory allocations) (PR [#47](https://github.com/philippgille/chromem-go/pull/47))
+- Improved query performance (5x faster, 99% fewer memory allocations) (PR [#47](https://github.com/philippgille/chromem-go/pull/47), [#53](https://github.com/philippgille/chromem-go/pull/53))
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Because `chromem-go` is embeddable it enables you to add retrieval augmented gen
 
 It's *not* a library to connect to Chroma and also not a reimplementation of it in Go. It's a database on its own.
 
-The focus is not scale (millions of documents) or number of features, but simplicity and performance for the most common use cases. On a mid-range 2020 Intel laptop CPU you can query 1,000 documents in 0.5 ms and 100,000 documents in 50-60 ms, both with just 44 memory allocations. See [Benchmarks](#benchmarks) for details.
+The focus is not scale (millions of documents) or number of features, but simplicity and performance for the most common use cases. On a mid-range 2020 Intel laptop CPU you can query 1,000 documents in 0.3 ms and 100,000 documents in 50-60 ms, both with just 41 memory allocations. See [Benchmarks](#benchmarks) for details.
 
 > ⚠️ The project is in beta, under heavy construction, and may introduce breaking changes in releases before `v1.0.0`. All changes are documented in the [`CHANGELOG`](./CHANGELOG.md).
 
@@ -197,18 +197,18 @@ goos: linux
 goarch: amd64
 pkg: github.com/philippgille/chromem-go
 cpu: 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
-BenchmarkCollection_Query_NoContent_100-8          10000     109957 ns/op     6487 B/op       44 allocs/op
-BenchmarkCollection_Query_NoContent_1000-8          2043     541337 ns/op    35667 B/op       44 allocs/op
-BenchmarkCollection_Query_NoContent_5000-8           361    4230542 ns/op   166729 B/op       44 allocs/op
-BenchmarkCollection_Query_NoContent_25000-8           79   16343977 ns/op   813902 B/op       44 allocs/op
-BenchmarkCollection_Query_NoContent_100000-8          18   63417540 ns/op  3205961 B/op       44 allocs/op
-BenchmarkCollection_Query_100-8                    10861     110167 ns/op     6480 B/op       44 allocs/op
-BenchmarkCollection_Query_1000-8                    2146     540489 ns/op    35669 B/op       44 allocs/op
-BenchmarkCollection_Query_5000-8                     442    4913970 ns/op   166748 B/op       44 allocs/op
-BenchmarkCollection_Query_25000-8                     88   15213089 ns/op   813909 B/op       44 allocs/op
-BenchmarkCollection_Query_100000-8                    19   55963675 ns/op  3206027 B/op       44 allocs/op
+BenchmarkCollection_Query_NoContent_100-8          10000     106441 ns/op     6393 B/op       41 allocs/op
+BenchmarkCollection_Query_NoContent_1000-8          2278     494254 ns/op    35570 B/op       41 allocs/op
+BenchmarkCollection_Query_NoContent_5000-8           416    2767125 ns/op   166634 B/op       41 allocs/op
+BenchmarkCollection_Query_NoContent_25000-8           70   15165139 ns/op   813800 B/op       41 allocs/op
+BenchmarkCollection_Query_NoContent_100000-8          19   58823464 ns/op  3205865 B/op       41 allocs/op
+BenchmarkCollection_Query_100-8                    11269     105990 ns/op     6385 B/op       41 allocs/op
+BenchmarkCollection_Query_1000-8                    2364     494212 ns/op    35574 B/op       41 allocs/op
+BenchmarkCollection_Query_5000-8                     481    2750438 ns/op   166647 B/op       41 allocs/op
+BenchmarkCollection_Query_25000-8                     93   13143419 ns/op   813805 B/op       41 allocs/op
+BenchmarkCollection_Query_100000-8                    20   51727357 ns/op  3205871 B/op       41 allocs/op
 PASS
-ok   github.com/philippgille/chromem-go 27.887s
+ok   github.com/philippgille/chromem-go 26.187s
 ```
 
 ## Motivation


### PR DESCRIPTION
`slices.SortFunc` is recommended over `sort.Slice` and more performant.

Query duration decreased ~17% in our benchmark:

```
goos: linux
goarch: amd64
pkg: github.com/philippgille/chromem-go
cpu: 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
                                    │    after     │               after2                │
                                    │    sec/op    │    sec/op     vs base               │
Collection_Query_NoContent_100-8      109.9µ ±  1%   106.3µ ±  2%   -3.23% (p=0.002 n=6)
Collection_Query_NoContent_1000-8     536.8µ ±  1%   490.7µ ±  1%   -8.60% (p=0.002 n=6)
Collection_Query_NoContent_5000-8     4.985m ± 15%   2.704m ±  5%  -45.76% (p=0.002 n=6)
Collection_Query_NoContent_25000-8    14.97m ± 10%   13.17m ± 11%  -11.99% (p=0.004 n=6)
Collection_Query_NoContent_100000-8   56.50m ± 11%   51.86m ± 13%   -8.21% (p=0.041 n=6)
Collection_Query_100-8                110.0µ ±  0%   106.8µ ±  0%   -2.91% (p=0.002 n=6)
Collection_Query_1000-8               536.8µ ±  0%   489.7µ ±  0%   -8.78% (p=0.002 n=6)
Collection_Query_5000-8               4.869m ±  5%   2.704m ±  6%  -44.46% (p=0.002 n=6)
Collection_Query_25000-8              15.01m ±  3%   13.05m ±  2%  -13.09% (p=0.002 n=6)
Collection_Query_100000-8             56.48m ±  4%   52.07m ±  5%   -7.81% (p=0.002 n=6)
geomean                               3.008m         2.492m        -17.13%

                                    │    after     │               after2               │
                                    │     B/op     │     B/op      vs base              │
Collection_Query_NoContent_100-8      6.330Ki ± 0%   6.235Ki ± 0%  -1.50% (p=0.002 n=6)
Collection_Query_NoContent_1000-8     34.83Ki ± 0%   34.74Ki ± 0%  -0.26% (p=0.002 n=6)
Collection_Query_NoContent_5000-8     162.8Ki ± 0%   162.7Ki ± 0%  -0.05% (p=0.002 n=6)
Collection_Query_NoContent_25000-8    794.8Ki ± 0%   794.7Ki ± 0%  -0.01% (p=0.002 n=6)
Collection_Query_NoContent_100000-8   3.057Mi ± 0%   3.057Mi ± 0%  -0.00% (p=0.002 n=6)
Collection_Query_100-8                6.329Ki ± 0%   6.234Ki ± 0%  -1.49% (p=0.002 n=6)
Collection_Query_1000-8               34.83Ki ± 0%   34.74Ki ± 0%  -0.26% (p=0.002 n=6)
Collection_Query_5000-8               162.8Ki ± 0%   162.7Ki ± 0%  -0.06% (p=0.002 n=6)
Collection_Query_25000-8              794.8Ki ± 0%   794.7Ki ± 0%  -0.01% (p=0.002 n=6)
Collection_Query_100000-8             3.057Mi ± 0%   3.057Mi ± 0%       ~ (p=0.065 n=6)
geomean                               155.0Ki        154.4Ki       -0.37%

                                    │   after    │              after2              │
                                    │ allocs/op  │ allocs/op   vs base              │
Collection_Query_NoContent_100-8      44.00 ± 0%   41.00 ± 0%  -6.82% (p=0.002 n=6)
Collection_Query_NoContent_1000-8     44.00 ± 0%   41.00 ± 0%  -6.82% (p=0.002 n=6)
Collection_Query_NoContent_5000-8     44.00 ± 0%   41.00 ± 0%  -6.82% (p=0.002 n=6)
Collection_Query_NoContent_25000-8    44.00 ± 0%   41.00 ± 0%  -6.82% (p=0.002 n=6)
Collection_Query_NoContent_100000-8   44.00 ± 0%   41.00 ± 0%  -6.82% (p=0.002 n=6)
Collection_Query_100-8                44.00 ± 0%   41.00 ± 0%  -6.82% (p=0.002 n=6)
Collection_Query_1000-8               44.00 ± 0%   41.00 ± 0%  -6.82% (p=0.002 n=6)
Collection_Query_5000-8               44.00 ± 0%   41.00 ± 0%  -6.82% (p=0.002 n=6)
Collection_Query_25000-8              44.00 ± 0%   41.00 ± 0%  -6.82% (p=0.002 n=6)
Collection_Query_100000-8             44.00 ± 0%   41.50 ± 1%  -5.68% (p=0.002 n=6)
geomean                               44.00        41.05       -6.71%
```