### PR TITLE
Use max heap for building query result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 vNext
 -----
 
-In this release the main feature is query performance improvement (5x faster, 99% fewer memory allocations). There's also a new code example for semantic search across 5,000 arXiv papers.
+In this release the main feature is query performance improvement (5x faster, 98% fewer memory allocations). There's also a new code example for semantic search across 5,000 arXiv papers.
 
 ### Added
 
@@ -18,7 +18,7 @@ In this release the main feature is query performance improvement (5x faster, 99
 ### Improved
 
 - Changed the example link target to directory instead of `main.go` file (PR [#43](https://github.com/philippgille/chromem-go/pull/43))
-- Improved query performance (5x faster, 99% fewer memory allocations) (PR [#47](https://github.com/philippgille/chromem-go/pull/47), [#53](https://github.com/philippgille/chromem-go/pull/53))
+- Improved query performance (5x faster, 98% fewer memory allocations) (PR [#47](https://github.com/philippgille/chromem-go/pull/47), [#53](https://github.com/philippgille/chromem-go/pull/53))
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Because `chromem-go` is embeddable it enables you to add retrieval augmented gen
 
 It's *not* a library to connect to Chroma and also not a reimplementation of it in Go. It's a database on its own.
 
-The focus is not scale (millions of documents) or number of features, but simplicity and performance for the most common use cases. On a mid-range 2020 Intel laptop CPU you can query 1,000 documents in 0.3 ms and 100,000 documents in 50-60 ms, both with just 41 memory allocations. See [Benchmarks](#benchmarks) for details.
+The focus is not scale (millions of documents) or number of features, but simplicity and performance for the most common use cases. On a mid-range 2020 Intel laptop CPU you can query 1,000 documents in 0.3 ms and 100,000 documents in 40 ms, with very few and small memory allocations. See [Benchmarks](#benchmarks) for details.
 
 > ⚠️ The project is in beta, under heavy construction, and may introduce breaking changes in releases before `v1.0.0`. All changes are documented in the [`CHANGELOG`](./CHANGELOG.md).
 
@@ -197,18 +197,18 @@ goos: linux
 goarch: amd64
 pkg: github.com/philippgille/chromem-go
 cpu: 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
-BenchmarkCollection_Query_NoContent_100-8          10000     106441 ns/op     6393 B/op       41 allocs/op
-BenchmarkCollection_Query_NoContent_1000-8          2278     494254 ns/op    35570 B/op       41 allocs/op
-BenchmarkCollection_Query_NoContent_5000-8           416    2767125 ns/op   166634 B/op       41 allocs/op
-BenchmarkCollection_Query_NoContent_25000-8           70   15165139 ns/op   813800 B/op       41 allocs/op
-BenchmarkCollection_Query_NoContent_100000-8          19   58823464 ns/op  3205865 B/op       41 allocs/op
-BenchmarkCollection_Query_100-8                    11269     105990 ns/op     6385 B/op       41 allocs/op
-BenchmarkCollection_Query_1000-8                    2364     494212 ns/op    35574 B/op       41 allocs/op
-BenchmarkCollection_Query_5000-8                     481    2750438 ns/op   166647 B/op       41 allocs/op
-BenchmarkCollection_Query_25000-8                     93   13143419 ns/op   813805 B/op       41 allocs/op
-BenchmarkCollection_Query_100000-8                    20   51727357 ns/op  3205871 B/op       41 allocs/op
+BenchmarkCollection_Query_NoContent_100-8          13164      90276 ns/op     5176 B/op       95 allocs/op
+BenchmarkCollection_Query_NoContent_1000-8          2142     520261 ns/op    13558 B/op      141 allocs/op
+BenchmarkCollection_Query_NoContent_5000-8           561    2150354 ns/op    47096 B/op      173 allocs/op
+BenchmarkCollection_Query_NoContent_25000-8          120    9890177 ns/op   211783 B/op      208 allocs/op
+BenchmarkCollection_Query_NoContent_100000-8          30   39574238 ns/op   810370 B/op      232 allocs/op
+BenchmarkCollection_Query_100-8                    13225      91058 ns/op     5177 B/op       95 allocs/op
+BenchmarkCollection_Query_1000-8                    2226     519693 ns/op    13552 B/op      140 allocs/op
+BenchmarkCollection_Query_5000-8                     550    2128121 ns/op    47108 B/op      173 allocs/op
+BenchmarkCollection_Query_25000-8                    100   10063260 ns/op   211705 B/op      205 allocs/op
+BenchmarkCollection_Query_100000-8                    30   39404005 ns/op   810295 B/op      229 allocs/op
 PASS
-ok   github.com/philippgille/chromem-go 26.187s
+ok   github.com/philippgille/chromem-go 28.402s
 ```
 
 ## Motivation


### PR DESCRIPTION
It requires more allocations (not constant anymore), but is 1) faster and 2) requires much *smaller* allocations, so overall a win.

```
goos: linux
goarch: amd64
pkg: github.com/philippgille/chromem-go
cpu: 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
                                    │    after2     │               after3                │
                                    │    sec/op     │    sec/op     vs base               │
Collection_Query_NoContent_100-8      106.32µ ±  2%   90.79µ ±  2%  -14.61% (p=0.002 n=6)
Collection_Query_NoContent_1000-8      490.7µ ±  1%   518.8µ ±  1%   +5.74% (p=0.002 n=6)
Collection_Query_NoContent_5000-8      2.704m ±  5%   2.144m ±  1%  -20.72% (p=0.002 n=6)
Collection_Query_NoContent_25000-8    13.171m ± 11%   9.947m ±  2%  -24.48% (p=0.002 n=6)
Collection_Query_NoContent_100000-8    51.86m ± 13%   39.75m ±  1%  -23.34% (p=0.002 n=6)
Collection_Query_100-8                106.77µ ±  0%   90.99µ ±  1%  -14.78% (p=0.002 n=6)
Collection_Query_1000-8                489.7µ ±  0%   595.2µ ± 13%  +21.55% (p=0.002 n=6)
Collection_Query_5000-8                2.704m ±  6%   2.556m ±  1%   -5.47% (p=0.002 n=6)
Collection_Query_25000-8               13.05m ±  2%   11.66m ±  1%  -10.65% (p=0.002 n=6)
Collection_Query_100000-8              52.07m ±  5%   39.70m ± 12%  -23.76% (p=0.002 n=6)
geomean                                2.492m         2.192m        -12.07%

                                    │    after2     │               after3                │
                                    │     B/op      │     B/op      vs base               │
Collection_Query_NoContent_100-8       6.235Ki ± 0%   5.030Ki ± 0%  -19.32% (p=0.002 n=6)
Collection_Query_NoContent_1000-8      34.74Ki ± 0%   13.24Ki ± 0%  -61.88% (p=0.002 n=6)
Collection_Query_NoContent_5000-8     162.74Ki ± 0%   45.99Ki ± 0%  -71.74% (p=0.002 n=6)
Collection_Query_NoContent_25000-8     794.7Ki ± 0%   206.7Ki ± 0%  -73.99% (p=0.002 n=6)
Collection_Query_NoContent_100000-8   3130.7Ki ± 0%   791.4Ki ± 0%  -74.72% (p=0.002 n=6)
Collection_Query_100-8                 6.234Ki ± 0%   5.033Ki ± 0%  -19.27% (p=0.002 n=6)
Collection_Query_1000-8                34.74Ki ± 0%   13.25Ki ± 0%  -61.87% (p=0.002 n=6)
Collection_Query_5000-8               162.73Ki ± 0%   46.04Ki ± 0%  -71.71% (p=0.002 n=6)
Collection_Query_25000-8               794.7Ki ± 0%   206.8Ki ± 0%  -73.98% (p=0.002 n=6)
Collection_Query_100000-8             3130.8Ki ± 0%   791.4Ki ± 0%  -74.72% (p=0.002 n=6)
geomean                                154.4Ki        54.97Ki       -64.40%

                                    │   after2   │               after3                │
                                    │ allocs/op  │  allocs/op   vs base                │
Collection_Query_NoContent_100-8      41.00 ± 0%    94.00 ± 1%  +129.27% (p=0.002 n=6)
Collection_Query_NoContent_1000-8     41.00 ± 0%   140.50 ± 0%  +242.68% (p=0.002 n=6)
Collection_Query_NoContent_5000-8     41.00 ± 0%   172.00 ± 1%  +319.51% (p=0.002 n=6)
Collection_Query_NoContent_25000-8    41.00 ± 0%   204.00 ± 1%  +397.56% (p=0.002 n=6)
Collection_Query_NoContent_100000-8   41.00 ± 0%   232.00 ± 3%  +465.85% (p=0.002 n=6)
Collection_Query_100-8                41.00 ± 0%    94.50 ± 1%  +130.49% (p=0.002 n=6)
Collection_Query_1000-8               41.00 ± 0%   141.00 ± 1%  +243.90% (p=0.002 n=6)
Collection_Query_5000-8               41.00 ± 0%   174.50 ± 2%  +325.61% (p=0.002 n=6)
Collection_Query_25000-8              41.00 ± 0%   205.50 ± 2%  +401.22% (p=0.002 n=6)
Collection_Query_100000-8             41.50 ± 1%   233.00 ± 1%  +461.45% (p=0.002 n=6)
geomean                               41.05         161.4       +293.09%
```