### PR TITLE
DB export and import with optional compression and encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ See the Godoc for details: <https://pkg.go.dev/github.com/philippgille/chromem-g
   - [X] Metadata filters: Exact matches
 - Storage:
   - [X] In-memory
-  - [X] Optional local persistence (file based, encoded as [gob](https://go.dev/blog/gob))
+  - [X] Backups: Export and import of the entire DB to/from a single file (optionally gzip-compressed and AES-GCM encrypted)
+  - [X] Optional immediate persistence (writes one file for each added collection and document, encoded as [gob](https://go.dev/blog/gob))
 - Data types:
   - [X] Documents (text)
 
@@ -168,8 +169,7 @@ See the Godoc for details: <https://pkg.go.dev/github.com/philippgille/chromem-g
 - Storage:
   - JSON as second encoding format
   - Write-ahead log (WAL) as second file format
-  - Compression
-  - Encryption (at rest)
+  - Compression and encryption not only for the export, but also for each collection/document file
   - Optional remote storage (S3, PostgreSQL, ...)
 - Data types:
   - Images

--- a/collection.go
+++ b/collection.go
@@ -21,6 +21,9 @@ type Collection struct {
 	documents        map[string]*Document
 	documentsLock    sync.RWMutex
 	embed            EmbeddingFunc
+
+	// ⚠️ When adding fields here, consider adding them to the persistence struct
+	// version in [DB.Export] as well!
 }
 
 // We don't export this yet to keep the API surface to the bare minimum.

--- a/collection.go
+++ b/collection.go
@@ -23,7 +23,7 @@ type Collection struct {
 	embed            EmbeddingFunc
 
 	// ⚠️ When adding fields here, consider adding them to the persistence struct
-	// version in [DB.Export] as well!
+	// versions in [DB.Export] and [DB.Import] as well!
 }
 
 // We don't export this yet to keep the API surface to the bare minimum.

--- a/collection.go
+++ b/collection.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"slices"
 	"sync"
@@ -48,11 +47,6 @@ func newCollection(name string, metadata map[string]string, embed EmbeddingFunc,
 	if dbDir != "" {
 		safeName := hash2hex(name)
 		c.persistDirectory = filepath.Join(dbDir, safeName)
-		// Create dir
-		err := os.MkdirAll(c.persistDirectory, 0o700)
-		if err != nil {
-			return nil, fmt.Errorf("couldn't create collection directory: %w", err)
-		}
 		// Persist name and metadata
 		metadataPath := filepath.Join(c.persistDirectory, metadataFileName)
 		metadataPath += ".gob"
@@ -63,7 +57,7 @@ func newCollection(name string, metadata map[string]string, embed EmbeddingFunc,
 			Name:     name,
 			Metadata: m,
 		}
-		err = persist(metadataPath, pc, false, "")
+		err := persist(metadataPath, pc, false, "")
 		if err != nil {
 			return nil, fmt.Errorf("couldn't persist collection metadata: %w", err)
 		}

--- a/collection.go
+++ b/collection.go
@@ -25,7 +25,7 @@ type Collection struct {
 
 // We don't export this yet to keep the API surface to the bare minimum.
 // Users create collections via [Client.CreateCollection].
-func newCollection(name string, metadata map[string]string, embed EmbeddingFunc, dir string) (*Collection, error) {
+func newCollection(name string, metadata map[string]string, embed EmbeddingFunc, dbDir string) (*Collection, error) {
 	// We copy the metadata to avoid data races in case the caller modifies the
 	// map after creating the collection while we range over it.
 	m := make(map[string]string, len(metadata))
@@ -42,9 +42,9 @@ func newCollection(name string, metadata map[string]string, embed EmbeddingFunc,
 	}
 
 	// Persistence
-	if dir != "" {
+	if dbDir != "" {
 		safeName := hash2hex(name)
-		c.persistDirectory = filepath.Join(dir, safeName)
+		c.persistDirectory = filepath.Join(dbDir, safeName)
 		// Create dir
 		err := os.MkdirAll(c.persistDirectory, 0o700)
 		if err != nil {
@@ -52,6 +52,7 @@ func newCollection(name string, metadata map[string]string, embed EmbeddingFunc,
 		}
 		// Persist name and metadata
 		metadataPath := filepath.Join(c.persistDirectory, metadataFileName)
+		metadataPath += ".gob"
 		pc := struct {
 			Name     string
 			Metadata map[string]string
@@ -59,7 +60,7 @@ func newCollection(name string, metadata map[string]string, embed EmbeddingFunc,
 			Name:     name,
 			Metadata: m,
 		}
-		err = persist(metadataPath, pc)
+		err = persist(metadataPath, pc, false, "")
 		if err != nil {
 			return nil, fmt.Errorf("couldn't persist collection metadata: %w", err)
 		}
@@ -233,8 +234,9 @@ func (c *Collection) AddDocument(ctx context.Context, doc Document) error {
 	// Persist the document
 	if c.persistDirectory != "" {
 		safeID := hash2hex(doc.ID)
-		filePath := filepath.Join(c.persistDirectory, safeID)
-		err := persist(filePath, doc)
+		docPath := filepath.Join(c.persistDirectory, safeID)
+		docPath += ".gob"
+		err := persist(docPath, doc, false, "")
 		if err != nil {
 			return fmt.Errorf("couldn't persist document: %w", err)
 		}

--- a/db.go
+++ b/db.go
@@ -251,13 +251,6 @@ func (db *DB) Export(filePath string, compress bool, encryptionKey string) error
 		}
 	}
 
-	// Create parent dir if it doesn't exist
-	parentDir := filepath.Dir(filePath)
-	err := os.MkdirAll(parentDir, 0o700)
-	if err != nil {
-		return fmt.Errorf("couldn't create parent directory: %w", err)
-	}
-
 	// Create persistence structs with exported fields so that they can be encoded
 	// as gob.
 	type persistenceCollection struct {
@@ -282,7 +275,7 @@ func (db *DB) Export(filePath string, compress bool, encryptionKey string) error
 		}
 	}
 
-	err = persist(filePath, persistenceDB, compress, encryptionKey)
+	err := persist(filePath, persistenceDB, compress, encryptionKey)
 	if err != nil {
 		return fmt.Errorf("couldn't export DB: %w", err)
 	}

--- a/db.go
+++ b/db.go
@@ -33,6 +33,9 @@ type DB struct {
 }
 
 // NewDB creates a new in-memory chromem-go DB.
+// While it doesn't write files when you add collections and documents, you can
+// still use [DB.Export] and [DB.Import] to export and import the the entire DB
+// from a file.
 func NewDB() *DB {
 	return &DB{
 		collections: make(map[string]*Collection),
@@ -51,6 +54,10 @@ func NewDB() *DB {
 // Currently the persistence is done synchronously on each write operation, and
 // each document addition leads to a new file, encoded as gob. In the future we
 // will make this configurable (encoding, async writes, WAL-based writes, etc.).
+//
+// In addition to persistence for each added collection and document you can use
+// [DB.Export] and [DB.Import] to export and import the entire DB to/from a file,
+// which also works for the pure in-memory DB.
 func NewPersistentDB(path string) (*DB, error) {
 	if path == "" {
 		path = "./chromem-go"

--- a/db.go
+++ b/db.go
@@ -167,11 +167,11 @@ func (db *DB) Import(filePath string, decryptionKey string) error {
 func (db *DB) Export(filePath string, compress bool, encryptionKey string) error {
 	if filePath == "" {
 		filePath = "./chromem-go.gob"
-		if encryptionKey != "" {
-			filePath += ".enc"
-		}
 		if compress {
 			filePath += ".gz"
+		}
+		if encryptionKey != "" {
+			filePath += ".enc"
 		}
 	}
 

--- a/db.go
+++ b/db.go
@@ -271,7 +271,12 @@ func (db *DB) Export(filePath string, compress bool, encryptionKey string) error
 		}
 	}
 
-	return persist(filePath, persistenceDB, compress, encryptionKey)
+	err = persist(filePath, persistenceDB, compress, encryptionKey)
+	if err != nil {
+		return fmt.Errorf("couldn't export DB: %w", err)
+	}
+
+	return nil
 }
 
 // CreateCollection creates a new collection with the given name and metadata.

--- a/db.go
+++ b/db.go
@@ -172,15 +172,15 @@ func NewPersistentDB(path string) (*DB, error) {
 // Existing collections are overwritten.
 //
 // - filePath: Mandatory, must not be empty
-// - decryptionKey: Optional, must be 32 bytes long if provided
-func (db *DB) Import(filePath string, decryptionKey string) error {
+// - encryptionKey: Optional, must be 32 bytes long if provided
+func (db *DB) Import(filePath string, encryptionKey string) error {
 	if filePath == "" {
 		return fmt.Errorf("file path is empty")
 	}
-	if decryptionKey != "" {
+	if encryptionKey != "" {
 		// AES 256 requires a 32 byte key
-		if len(decryptionKey) != 32 {
-			return errors.New("decryption key must be 32 bytes long")
+		if len(encryptionKey) != 32 {
+			return errors.New("encryption key must be 32 bytes long")
 		}
 	}
 
@@ -211,7 +211,7 @@ func (db *DB) Import(filePath string, decryptionKey string) error {
 	db.collectionsLock.Lock()
 	defer db.collectionsLock.Unlock()
 
-	err = read(filePath, &persistenceDB, decryptionKey)
+	err = read(filePath, &persistenceDB, encryptionKey)
 	if err != nil {
 		return fmt.Errorf("couldn't read file: %w", err)
 	}

--- a/db.go
+++ b/db.go
@@ -226,10 +226,12 @@ func (db *DB) Import(filePath string, decryptionKey string) error {
 // Export exports the DB to a file at the given path. The file is encoded as gob,
 // optionally compressed with flate (as gzip) and optionally encrypted with AES-GCM.
 // This works for both the in-memory and persistent DBs.
-//
-// If filePath is empty, it defaults to "./chromem-go.gob" (+ ".gz" + ".enc").
 // If the file exists, it's overwritten, otherwise created.
-// For encryption you must provide a 32 bytes long key.
+//
+//   - filePath: If empty, it defaults to "./chromem-go.gob" (+ ".gz" + ".enc")
+//   - compress: Optional. Compresses as gzip if true.
+//   - encryptionKey: Optional. Encrypts with AES-GCM if provided. Must be 32 bytes
+//     long if provided.
 func (db *DB) Export(filePath string, compress bool, encryptionKey string) error {
 	if filePath == "" {
 		filePath = "./chromem-go.gob"

--- a/db.go
+++ b/db.go
@@ -158,7 +158,14 @@ func NewPersistentDB(path string) (*DB, error) {
 	return db, nil
 }
 
-// TODO: Godoc
+// Import imports the DB from a file at the given path. The file must be encoded
+// as gob and can optionally be compressed with flate (as gzip) and encrypted
+// with AES-GCM.
+// This works for both the in-memory and persistent DBs.
+// Existing collections are overwritten.
+//
+// - filePath: Mandatory, must not be empty
+// - decryptionKey: Optional, must be 32 bytes long if provided
 func (db *DB) Import(filePath string, decryptionKey string) error {
 	if filePath == "" {
 		return fmt.Errorf("file path is empty")

--- a/db.go
+++ b/db.go
@@ -1,16 +1,9 @@
 package chromem
 
 import (
-	"bytes"
-	"compress/gzip"
 	"context"
-	"crypto/aes"
-	"crypto/cipher"
-	"crypto/rand"
-	"encoding/gob"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -179,87 +172,7 @@ func (db *DB) Export(filePath string, compress bool, encryptionKey string) error
 		}
 	}
 
-	// AES 256 requires a 32 byte key
-	if encryptionKey != "" {
-		if len(encryptionKey) != 32 {
-			return errors.New("encryption key must be 32 bytes long")
-		}
-	}
-
-	// If path doesn't exist, create the parent path.
-	// If path exists and it's a directory, return an error.
-	fi, err := os.Stat(filePath)
-	if err != nil {
-		if !errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("couldn't get info about export path: %w", err)
-		} else {
-			// If the file doesn't exist, create the parent path
-			err := os.MkdirAll(filepath.Dir(filePath), 0o700)
-			if err != nil {
-				return fmt.Errorf("couldn't create export directory: %w", err)
-			}
-		}
-	} else if fi.IsDir() {
-		return fmt.Errorf("path is a directory: %s", filePath)
-	}
-
-	// Open file for writing
-	f, err := os.Create(filePath)
-	if err != nil {
-		return fmt.Errorf("couldn't create file: %w", err)
-	}
-	defer f.Close()
-
-	// We want to:
-	// Encode as gob -> compress with flate -> encrypt with AES-GCM -> write file.
-	// To reduce memory usage we chain the writers instead of buffering, so we start
-	// from the end. For AES GCM sealing the stdlib doesn't provide a writer though.
-
-	var w io.Writer
-	if encryptionKey == "" {
-		w = f
-	} else {
-		w = &bytes.Buffer{}
-	}
-	if compress {
-		gzw := gzip.NewWriter(w)
-		defer gzw.Close()
-		w = gzw
-	}
-	enc := gob.NewEncoder(w)
-
-	// Start encoding, it will write to the chain of writers.
-	if err := enc.Encode(db); err != nil {
-		return fmt.Errorf("couldn't encode DB as gob: %w", err)
-	}
-
-	// Without encyrption, the chain is done and the file is written.
-	if encryptionKey == "" {
-		return nil
-	}
-
-	// Otherwise, encrypt and then write to the file
-	block, err := aes.NewCipher([]byte(encryptionKey))
-	if err != nil {
-		return fmt.Errorf("couldn't create new AES cipher: %w", err)
-	}
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return fmt.Errorf("couldn't create GCM wrapper: %w", err)
-	}
-	nonce := make([]byte, gcm.NonceSize())
-	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-		return fmt.Errorf("couldn't read random bytes for nonce: %w", err)
-	}
-	// w is a *bytes.Buffer
-	buf := w.(*bytes.Buffer)
-	encrypted := gcm.Seal(nonce, nonce, buf.Bytes(), nil)
-	_, err = f.Write(encrypted)
-	if err != nil {
-		return fmt.Errorf("couldn't write encrypted data: %w", err)
-	}
-
-	return nil
+	return persist(filePath, db, compress, encryptionKey)
 }
 
 // CreateCollection creates a new collection with the given name and metadata.

--- a/db.go
+++ b/db.go
@@ -163,7 +163,13 @@ func (db *DB) Import(filePath string, decryptionKey string) error {
 	return errors.New("not implemented") // TODO: implement
 }
 
-// TODO: Godoc
+// Export exports the DB to a file at the given path. The file is encoded as gob,
+// optionally compressed with flate (as gzip) and optionally encrypted with AES-GCM.
+// This works for both the in-memory and persistent DBs.
+//
+// If filePath is empty, it defaults to "./chromem-go.gob" (+ ".gz" + ".enc").
+// If the file exists, it's overwritten, otherwise created.
+// For encryption you must provide a 32 bytes long key.
 func (db *DB) Export(filePath string, compress bool, encryptionKey string) error {
 	if filePath == "" {
 		filePath = "./chromem-go.gob"

--- a/db.go
+++ b/db.go
@@ -123,7 +123,7 @@ func NewPersistentDB(path string) (*DB, error) {
 					Name     string
 					Metadata map[string]string
 				}{}
-				err := read(fPath, &pc)
+				err := read(fPath, &pc, "")
 				if err != nil {
 					return nil, fmt.Errorf("couldn't read collection metadata: %w", err)
 				}
@@ -132,7 +132,7 @@ func NewPersistentDB(path string) (*DB, error) {
 			} else if filepath.Ext(collectionDirEntry.Name()) == ".gob" {
 				// Read document
 				d := &Document{}
-				err := read(fPath, d)
+				err := read(fPath, d, "")
 				if err != nil {
 					return nil, fmt.Errorf("couldn't read document: %w", err)
 				}
@@ -198,8 +198,7 @@ func (db *DB) Import(filePath string, decryptionKey string) error {
 	db.collectionsLock.Lock()
 	defer db.collectionsLock.Unlock()
 
-	// TODO: Implement decryption and decompression
-	err = read(filePath, &persistenceDB)
+	err = read(filePath, &persistenceDB, decryptionKey)
 	if err != nil {
 		return fmt.Errorf("couldn't read file: %w", err)
 	}

--- a/db.go
+++ b/db.go
@@ -213,9 +213,11 @@ func (db *DB) Import(filePath string, decryptionKey string) error {
 		c := &Collection{
 			Name: pc.Name,
 
-			persistDirectory: filepath.Join(db.persistDirectory, hash2hex(pc.Name)),
-			metadata:         pc.Metadata,
-			documents:        pc.Documents,
+			metadata:  pc.Metadata,
+			documents: pc.Documents,
+		}
+		if db.persistDirectory != "" {
+			c.persistDirectory = filepath.Join(db.persistDirectory, hash2hex(pc.Name))
 		}
 		db.collections[c.Name] = c
 	}

--- a/db.go
+++ b/db.go
@@ -247,6 +247,13 @@ func (db *DB) Export(filePath string, compress bool, encryptionKey string) error
 		}
 	}
 
+	// Create parent dir if it doesn't exist
+	parentDir := filepath.Dir(filePath)
+	err := os.MkdirAll(parentDir, 0o700)
+	if err != nil {
+		return fmt.Errorf("couldn't create parent directory: %w", err)
+	}
+
 	// Create persistence structs with exported fields so that they can be encoded
 	// as gob.
 	type persistenceCollection struct {

--- a/db.go
+++ b/db.go
@@ -170,6 +170,12 @@ func (db *DB) Import(filePath string, decryptionKey string) error {
 	if filePath == "" {
 		return fmt.Errorf("file path is empty")
 	}
+	if decryptionKey != "" {
+		// AES 256 requires a 32 byte key
+		if len(decryptionKey) != 32 {
+			return errors.New("decryption key must be 32 bytes long")
+		}
+	}
 
 	// If the file doesn't exist or is a directory, return an error.
 	fi, err := os.Stat(filePath)
@@ -232,6 +238,12 @@ func (db *DB) Export(filePath string, compress bool, encryptionKey string) error
 		}
 		if encryptionKey != "" {
 			filePath += ".enc"
+		}
+	}
+	if encryptionKey != "" {
+		// AES 256 requires a 32 byte key
+		if len(encryptionKey) != 32 {
+			return errors.New("encryption key must be 32 bytes long")
 		}
 	}
 

--- a/document.go
+++ b/document.go
@@ -13,7 +13,7 @@ type Document struct {
 	Content   string
 
 	// ⚠️ When adding unexported fields here, consider adding a persistence struct
-	// version of this in [DB.Export].
+	// version of this in [DB.Export] and [DB.Import].
 }
 
 // NewDocument creates a new document, including its embeddings.

--- a/document.go
+++ b/document.go
@@ -11,6 +11,9 @@ type Document struct {
 	Metadata  map[string]string
 	Embedding []float32
 	Content   string
+
+	// ⚠️ When adding unexported fields here, consider adding a persistence struct
+	// version of this in [DB.Export].
 }
 
 // NewDocument creates a new document, including its embeddings.

--- a/persistence.go
+++ b/persistence.go
@@ -1,11 +1,20 @@
 package chromem
 
 import (
+	"bytes"
+	"compress/gzip"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/gob"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"os"
+	"path/filepath"
 )
 
 const metadataFileName = "00000000"
@@ -19,20 +28,92 @@ func hash2hex(name string) string {
 }
 
 // persist persists an object to a file at the given path. The object is serialized
-// as gob.
-func persist(filePath string, obj any) error {
-	filePath += ".gob"
+// as gob, optionally compressed with flate (as gzip) and optionally encrypted with
+// AES-GCM. The encryption key must be 32 bytes long. If the file exists, it's
+// overwritten, otherwise created.
+func persist(filePath string, obj any, compress bool, encryptionKey string) error {
+	if filePath == "" {
+		return fmt.Errorf("file path is empty")
+	}
 
+	// AES 256 requires a 32 byte key
+	if encryptionKey != "" {
+		if len(encryptionKey) != 32 {
+			return errors.New("encryption key must be 32 bytes long")
+		}
+	}
+
+	// If path doesn't exist, create the parent path.
+	// If path exists and it's a directory, return an error.
+	fi, err := os.Stat(filePath)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("couldn't get info about the path: %w", err)
+		} else {
+			// If the file doesn't exist, create the parent path
+			err := os.MkdirAll(filepath.Dir(filePath), 0o700)
+			if err != nil {
+				return fmt.Errorf("couldn't create parent directories to path: %w", err)
+			}
+		}
+	} else if fi.IsDir() {
+		return fmt.Errorf("path is a directory: %s", filePath)
+	}
+
+	// Open file for writing
 	f, err := os.Create(filePath)
 	if err != nil {
-		return fmt.Errorf("couldn't create file '%s': %w", filePath, err)
+		return fmt.Errorf("couldn't create file: %w", err)
 	}
 	defer f.Close()
 
-	enc := gob.NewEncoder(f)
-	err = enc.Encode(obj)
-	if err != nil {
+	// We want to:
+	// Encode as gob -> compress with flate -> encrypt with AES-GCM -> write file.
+	// To reduce memory usage we chain the writers instead of buffering, so we start
+	// from the end. For AES GCM sealing the stdlib doesn't provide a writer though.
+
+	var w io.Writer
+	if encryptionKey == "" {
+		w = f
+	} else {
+		w = &bytes.Buffer{}
+	}
+	if compress {
+		gzw := gzip.NewWriter(w)
+		defer gzw.Close()
+		w = gzw
+	}
+	enc := gob.NewEncoder(w)
+
+	// Start encoding, it will write to the chain of writers.
+	if err := enc.Encode(obj); err != nil {
 		return fmt.Errorf("couldn't encode or write object: %w", err)
+	}
+
+	// Without encyrption, the chain is done and the file is written.
+	if encryptionKey == "" {
+		return nil
+	}
+
+	// Otherwise, encrypt and then write to the file
+	block, err := aes.NewCipher([]byte(encryptionKey))
+	if err != nil {
+		return fmt.Errorf("couldn't create new AES cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return fmt.Errorf("couldn't create GCM wrapper: %w", err)
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return fmt.Errorf("couldn't read random bytes for nonce: %w", err)
+	}
+	// w is a *bytes.Buffer
+	buf := w.(*bytes.Buffer)
+	encrypted := gcm.Seal(nonce, nonce, buf.Bytes(), nil)
+	_, err = f.Write(encrypted)
+	if err != nil {
+		return fmt.Errorf("couldn't write encrypted data: %w", err)
 	}
 
 	return nil

--- a/persistence.go
+++ b/persistence.go
@@ -134,16 +134,16 @@ func persist(filePath string, obj any, compress bool, encryptionKey string) erro
 
 // read reads an object from a file at the given path. The object is deserialized
 // from gob. `obj` must be a pointer to an instantiated object. The file may
-// optionally be compressed as gzip and/or encrypted with AES-GCM. The decryption
+// optionally be compressed as gzip and/or encrypted with AES-GCM. The encryption
 // key must be 32 bytes long.
-func read(filePath string, obj any, decryptionKey string) error {
+func read(filePath string, obj any, encryptionKey string) error {
 	if filePath == "" {
 		return fmt.Errorf("file path is empty")
 	}
 	// AES 256 requires a 32 byte key
-	if decryptionKey != "" {
-		if len(decryptionKey) != 32 {
-			return errors.New("decryption key must be 32 bytes long")
+	if encryptionKey != "" {
+		if len(encryptionKey) != 32 {
+			return errors.New("encryption key must be 32 bytes long")
 		}
 	}
 
@@ -155,12 +155,12 @@ func read(filePath string, obj any, decryptionKey string) error {
 	var r io.Reader
 
 	// Decrypt if an encryption key is provided
-	if decryptionKey != "" {
+	if encryptionKey != "" {
 		encrypted, err := os.ReadFile(filePath)
 		if err != nil {
 			return fmt.Errorf("couldn't read file: %w", err)
 		}
-		block, err := aes.NewCipher([]byte(decryptionKey))
+		block, err := aes.NewCipher([]byte(encryptionKey))
 		if err != nil {
 			return fmt.Errorf("couldn't create AES cipher: %w", err)
 		}

--- a/persistence_test.go
+++ b/persistence_test.go
@@ -26,7 +26,8 @@ func TestPersistence(t *testing.T) {
 		Bar: []float32{-0.40824828, 0.40824828, 0.81649655}, // normalized version of `{-0.1, 0.1, 0.2}`
 	}
 
-	persist(tempDir, obj)
+	tempFilePath := tempDir + ".gob"
+	persist(tempFilePath, obj, false, "")
 
 	// Check if the file exists.
 	_, err = os.Stat(tempDir + ".gob")

--- a/persistence_test.go
+++ b/persistence_test.go
@@ -1,21 +1,21 @@
 package chromem
 
 import (
-	"bytes"
+	"compress/gzip"
 	"encoding/gob"
+	"math/rand"
 	"os"
 	"reflect"
 	"testing"
+	"time"
 )
 
-func TestPersistence(t *testing.T) {
+func TestPersistenceWrite(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "chromem-go")
 	if err != nil {
 		t.Fatal("expected nil, got", err)
 	}
-	t.Cleanup(func() {
-		_ = os.RemoveAll(tempDir)
-	})
+	defer os.RemoveAll(tempDir)
 
 	type s struct {
 		Foo string
@@ -26,25 +26,184 @@ func TestPersistence(t *testing.T) {
 		Bar: []float32{-0.40824828, 0.40824828, 0.81649655}, // normalized version of `{-0.1, 0.1, 0.2}`
 	}
 
-	tempFilePath := tempDir + ".gob"
-	persist(tempFilePath, obj, false, "")
+	t.Run("gob", func(t *testing.T) {
+		tempFilePath := tempDir + ".gob"
+		persist(tempFilePath, obj, false, "")
+
+		// Check if the file exists.
+		_, err = os.Stat(tempFilePath)
+		if err != nil {
+			t.Fatal("expected nil, got", err)
+		}
+
+		// Read file and decode
+		f, err := os.Open(tempFilePath)
+		if err != nil {
+			t.Fatal("expected nil, got", err)
+		}
+		defer f.Close()
+		d := gob.NewDecoder(f)
+		res := s{}
+		err = d.Decode(&res)
+		if err != nil {
+			t.Fatal("expected nil, got", err)
+		}
+
+		// Compare
+		if !reflect.DeepEqual(obj, res) {
+			t.Fatalf("expected %+v, got %+v", obj, res)
+		}
+	})
+
+	t.Run("gob gzipped", func(t *testing.T) {
+		tempFilePath := tempDir + ".gob.gz"
+		persist(tempFilePath, obj, true, "")
+
+		// Check if the file exists.
+		_, err = os.Stat(tempFilePath)
+		if err != nil {
+			t.Fatal("expected nil, got", err)
+		}
+
+		// Read file, decompress and decode
+		f, err := os.Open(tempFilePath)
+		if err != nil {
+			t.Fatal("expected nil, got", err)
+		}
+		defer f.Close()
+		gzr, err := gzip.NewReader(f)
+		if err != nil {
+			t.Fatal("expected nil, got", err)
+		}
+		d := gob.NewDecoder(gzr)
+		res := s{}
+		err = d.Decode(&res)
+		if err != nil {
+			t.Fatal("expected nil, got", err)
+		}
+
+		// Compare
+		if !reflect.DeepEqual(obj, res) {
+			t.Fatalf("expected %+v, got %+v", obj, res)
+		}
+	})
+}
+
+func TestPersistenceRead(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "chromem-go")
+	if err != nil {
+		t.Fatal("expected nil, got", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	type s struct {
+		Foo string
+		Bar []float32
+	}
+	obj := s{
+		Foo: "test",
+		Bar: []float32{-0.40824828, 0.40824828, 0.81649655}, // normalized version of `{-0.1, 0.1, 0.2}`
+	}
+
+	t.Run("gob", func(t *testing.T) {
+		tempFilePath := tempDir + ".gob"
+		f, err := os.Create(tempFilePath)
+		if err != nil {
+			t.Fatal("expected nil, got", err)
+		}
+		defer f.Close()
+		enc := gob.NewEncoder(f)
+		err = enc.Encode(obj)
+		if err != nil {
+			t.Fatal("expected nil, got", err)
+		}
+
+		// Read the file.
+		var res s
+		err = read(tempFilePath, &res, "")
+		if err != nil {
+			t.Fatal("expected nil, got", err)
+		}
+
+		// Compare
+		if !reflect.DeepEqual(obj, res) {
+			t.Fatalf("expected %+v, got %+v", obj, res)
+		}
+	})
+
+	t.Run("gob gzipped", func(t *testing.T) {
+		tempFilePath := tempDir + ".gob.gz"
+		f, err := os.Create(tempFilePath)
+		if err != nil {
+			t.Fatal("expected nil, got", err)
+		}
+		defer f.Close()
+		gzw := gzip.NewWriter(f)
+		enc := gob.NewEncoder(gzw)
+		err = enc.Encode(obj)
+		if err != nil {
+			t.Fatal("expected nil, got", err)
+		}
+		err = gzw.Close()
+		if err != nil {
+			t.Fatal("expected nil, got", err)
+		}
+
+		// Read the file.
+		var res s
+		err = read(tempFilePath, &res, "")
+		if err != nil {
+			t.Fatal("expected nil, got", err)
+		}
+
+		// Compare
+		if !reflect.DeepEqual(obj, res) {
+			t.Fatalf("expected %+v, got %+v", obj, res)
+		}
+	})
+}
+
+func TestPersistenceEncryption(t *testing.T) {
+	// Instead of copy pasting encryption/decryption code, we resort to using both
+	// functions under test, instead of one combined with an independent implementation.
+
+	tempDir, err := os.MkdirTemp("", "chromem-go")
+	if err != nil {
+		t.Fatal("expected nil, got", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	type s struct {
+		Foo string
+		Bar []float32
+	}
+	obj := s{
+		Foo: "test",
+		Bar: []float32{-0.40824828, 0.40824828, 0.81649655}, // normalized version of `{-0.1, 0.1, 0.2}`
+	}
+
+	tempFilePath := tempDir + ".gob.enc"
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+	encryptionKey := randomString(r, 32)
+	err = persist(tempFilePath, obj, false, encryptionKey)
+	if err != nil {
+		t.Fatal("expected nil, got", err)
+	}
 
 	// Check if the file exists.
-	_, err = os.Stat(tempDir + ".gob")
+	_, err = os.Stat(tempFilePath)
 	if err != nil {
 		t.Fatal("expected nil, got", err)
 	}
-	// Check if the file contains the expected data.
-	b, err := os.ReadFile(tempDir + ".gob")
+
+	// Read the file.
+	var res s
+	err = read(tempFilePath, &res, encryptionKey)
 	if err != nil {
 		t.Fatal("expected nil, got", err)
 	}
-	d := gob.NewDecoder(bytes.NewReader(b))
-	res := s{}
-	err = d.Decode(&res)
-	if err != nil {
-		t.Fatal("expected nil, got", err)
-	}
+
+	// Compare
 	if !reflect.DeepEqual(obj, res) {
 		t.Fatalf("expected %+v, got %+v", obj, res)
 	}


### PR DESCRIPTION
This PR
- Adds `DB.Export()` and `DB.Import()`
  - The export is always gob encoded. It can optionally be compressed with gzip and optionally be encrypted with AES-GCM
  - The import auto-detects gzip compression
- Adds unit tests for them (export/import)
- Implements the compression and encryption in the existing `persist()` and `read()` functions, so we can reuse them later if we want to use them for the regular persistent DB, and not only for export/import
- Extends the unit tests for them accordingly (persist/read compression+encryption)