### PR TITLE
Add optional compression to regular persistence

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -22,7 +22,7 @@ func TestNewPersistentDB(t *testing.T) {
 			t.Fatal("expected path to not exist, got", err)
 		}
 
-		db, err := NewPersistentDB(path)
+		db, err := NewPersistentDB(path, false)
 		if err != nil {
 			t.Fatal("expected no error, got", err)
 		}
@@ -42,7 +42,7 @@ func TestNewPersistentDB(t *testing.T) {
 		}
 		defer os.RemoveAll(path)
 
-		db, err := NewPersistentDB(path)
+		db, err := NewPersistentDB(path, false)
 		if err != nil {
 			t.Fatal("expected no error, got", err)
 		}
@@ -60,7 +60,7 @@ func TestNewPersistentDB_Errors(t *testing.T) {
 		}
 		defer os.RemoveAll(f.Name())
 
-		_, err = NewPersistentDB(f.Name())
+		_, err = NewPersistentDB(f.Name(), false)
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}

--- a/examples/rag-wikipedia-ollama/main.go
+++ b/examples/rag-wikipedia-ollama/main.go
@@ -39,7 +39,7 @@ func main() {
 	// Set up chromem-go with persistence, so that when the program restarts, the
 	// DB's data is still available.
 	log.Println("Setting up chromem-go...")
-	db, err := chromem.NewPersistentDB("./db")
+	db, err := chromem.NewPersistentDB("./db", false)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/semantic-search-arxiv-openai/main.go
+++ b/examples/semantic-search-arxiv-openai/main.go
@@ -22,7 +22,7 @@ func main() {
 	// Set up chromem-go with persistence, so that when the program restarts, the
 	// DB's data is still available.
 	log.Println("Setting up chromem-go...")
-	db, err := chromem.NewPersistentDB("./db")
+	db, err := chromem.NewPersistentDB("./db", false)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
In https://github.com/philippgille/chromem-go/pull/58 we added `DB.Export()` for which we extended the existing `persist()` function with optional compression. Now we can also make use of it for the "regular" persistence (i.e. `PersistentDB` which writes a file for each collection and document addition).