### PR TITLE
add: Delete to delete a documents from a collection

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -270,6 +270,9 @@ func (c *Collection) Delete(_ context.Context, where, whereDocument map[string]s
 
 	var docIDs []string
 
+	c.documentsLock.Lock()
+	defer c.documentsLock.Unlock()
+
 	if where != nil || whereDocument != nil {
 		// metadata + content filters
 		filteredDocs := filterDocs(c.documents, where, whereDocument)
@@ -284,9 +287,6 @@ func (c *Collection) Delete(_ context.Context, where, whereDocument map[string]s
 	if len(docIDs) == 0 {
 		return nil
 	}
-
-	c.documentsLock.Lock()
-	defer c.documentsLock.Unlock()
 
 	for _, docID := range docIDs {
 		delete(c.documents, docID)

--- a/persistence.go
+++ b/persistence.go
@@ -225,3 +225,19 @@ func read(filePath string, obj any, encryptionKey string) error {
 
 	return nil
 }
+
+// remove removes a file at the given path. If the file doesn't exist, it's a no-op.
+func remove(filePath string) error {
+	if filePath == "" {
+		return fmt.Errorf("file path is empty")
+	}
+
+	err := os.Remove(filePath)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("couldn't remove file %q: %w", filePath, err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Hey there!

First off: This is the only embedded VectorDB I found for Go.. and it works really well - great work! :pray: 

This PR adds the `Delete` function to delete a single document from a collection, similar to ChromaDB's [`collection.Delete()`](https://docs.trychroma.com/api-reference#methods-on-collection)

Upstream reference: https://github.com/chroma-core/chroma/blob/ce5c6b35e7ee7b2786eec6e3f5e7c821fb30d844/chromadb/api/segment.py#L581-L646
