### PR TITLE
Add building of examples to CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,3 +30,33 @@ jobs:
 
     - name: Test
       run: go test -v -race ./...
+
+  examples:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # We make use of the `slices` feature, only available in 1.21 and newer
+        go-version: [ '1.21', '1.22' ]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Build minimal example
+      run: |
+        cd examples/minimal
+        go build -v ./...
+
+    - name: Build RAG Wikipedia Ollama
+      run: |
+        cd examples/rag-wikipedia-ollama
+        go build -v ./...
+
+    - name: Semantic search arXiv OpenAI
+      run: |
+        cd examples/semantic-search-arxiv-openai
+        go build -v ./...


### PR DESCRIPTION
As noticed in https://github.com/philippgille/chromem-go/pull/64, the examples aren't part of the CI build, so when doing breaking changes the examples could end up with compile errors.