### PR TITLE
Export to io.Writer

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -63,7 +63,7 @@ func newCollection(name string, metadata map[string]string, embed EmbeddingFunc,
 			Name:     name,
 			Metadata: m,
 		}
-		err := persist(metadataPath, pc, compress, "")
+		err := persistToFile(metadataPath, pc, compress, "")
 		if err != nil {
 			return nil, fmt.Errorf("couldn't persist collection metadata: %w", err)
 		}
@@ -237,7 +237,7 @@ func (c *Collection) AddDocument(ctx context.Context, doc Document) error {
 	// Persist the document
 	if c.persistDirectory != "" {
 		docPath := c.getDocPath(doc.ID)
-		err := persist(docPath, doc, c.compress, "")
+		err := persistToFile(docPath, doc, c.compress, "")
 		if err != nil {
 			return fmt.Errorf("couldn't persist document to %q: %w", docPath, err)
 		}
@@ -252,7 +252,6 @@ func (c *Collection) AddDocument(ctx context.Context, doc Document) error {
 //   - whereDocument: Conditional filtering on documents. Optional.
 //   - ids: The ids of the documents to delete. If empty, all documents are deleted.
 func (c *Collection) Delete(_ context.Context, where, whereDocument map[string]string, ids ...string) error {
-
 	// must have at least one of where, whereDocument or ids
 	if len(where) == 0 && len(whereDocument) == 0 && len(ids) == 0 {
 		return fmt.Errorf("must have at least one of where, whereDocument or ids")
@@ -294,7 +293,7 @@ func (c *Collection) Delete(_ context.Context, where, whereDocument map[string]s
 		// Remove the document from disk
 		if c.persistDirectory != "" {
 			docPath := c.getDocPath(docID)
-			err := remove(docPath)
+			err := removeFile(docPath)
 			if err != nil {
 				return fmt.Errorf("couldn't remove document at %q: %w", docPath, err)
 			}
@@ -302,7 +301,6 @@ func (c *Collection) Delete(_ context.Context, where, whereDocument map[string]s
 	}
 
 	return nil
-
 }
 
 // Count returns the number of documents in the collection.

--- a/db.go
+++ b/db.go
@@ -255,7 +255,22 @@ func (db *DB) Import(filePath string, encryptionKey string) error {
 //   - compress: Optional. Compresses as gzip if true.
 //   - encryptionKey: Optional. Encrypts with AES-GCM if provided. Must be 32 bytes
 //     long if provided.
+//
+// Deprecated: Use [DB.ExportToFile] instead.
 func (db *DB) Export(filePath string, compress bool, encryptionKey string) error {
+	return db.ExportToFile(filePath, compress, encryptionKey)
+}
+
+// ExportToFile exports the DB to a file at the given path. The file is encoded as gob,
+// optionally compressed with flate (as gzip) and optionally encrypted with AES-GCM.
+// This works for both the in-memory and persistent DBs.
+// If the file exists, it's overwritten, otherwise created.
+//
+//   - filePath: If empty, it defaults to "./chromem-go.gob" (+ ".gz" + ".enc")
+//   - compress: Optional. Compresses as gzip if true.
+//   - encryptionKey: Optional. Encrypts with AES-GCM if provided. Must be 32 bytes
+//     long if provided.
+func (db *DB) ExportToFile(filePath string, compress bool, encryptionKey string) error {
 	if filePath == "" {
 		filePath = "./chromem-go.gob"
 		if compress {

--- a/db.go
+++ b/db.go
@@ -142,7 +142,7 @@ func NewPersistentDB(path string, compress bool) (*DB, error) {
 					Name     string
 					Metadata map[string]string
 				}{}
-				err := read(fPath, &pc, "")
+				err := readFromFile(fPath, &pc, "")
 				if err != nil {
 					return nil, fmt.Errorf("couldn't read collection metadata: %w", err)
 				}
@@ -151,7 +151,7 @@ func NewPersistentDB(path string, compress bool) (*DB, error) {
 			} else if strings.HasSuffix(collectionDirEntry.Name(), ext) {
 				// Read document
 				d := &Document{}
-				err := read(fPath, d, "")
+				err := readFromFile(fPath, d, "")
 				if err != nil {
 					return nil, fmt.Errorf("couldn't read document: %w", err)
 				}
@@ -223,7 +223,7 @@ func (db *DB) Import(filePath string, encryptionKey string) error {
 	db.collectionsLock.Lock()
 	defer db.collectionsLock.Unlock()
 
-	err = read(filePath, &persistenceDB, encryptionKey)
+	err = readFromFile(filePath, &persistenceDB, encryptionKey)
 	if err != nil {
 		return fmt.Errorf("couldn't read file: %w", err)
 	}
@@ -295,7 +295,7 @@ func (db *DB) Export(filePath string, compress bool, encryptionKey string) error
 		}
 	}
 
-	err := persist(filePath, persistenceDB, compress, encryptionKey)
+	err := persistToFile(filePath, persistenceDB, compress, encryptionKey)
 	if err != nil {
 		return fmt.Errorf("couldn't export DB: %w", err)
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -139,7 +139,7 @@ func TestDB_ImportExport(t *testing.T) {
 			}
 
 			// Export
-			err = orig.Export(tc.filePath, tc.compress, tc.encryptionKey)
+			err = orig.ExportToFile(tc.filePath, tc.compress, tc.encryptionKey)
 			if err != nil {
 				t.Fatal("expected no error, got", err)
 			}

--- a/persistence_test.go
+++ b/persistence_test.go
@@ -28,7 +28,7 @@ func TestPersistenceWrite(t *testing.T) {
 
 	t.Run("gob", func(t *testing.T) {
 		tempFilePath := tempDir + ".gob"
-		persist(tempFilePath, obj, false, "")
+		persistToFile(tempFilePath, obj, false, "")
 
 		// Check if the file exists.
 		_, err = os.Stat(tempFilePath)
@@ -57,7 +57,7 @@ func TestPersistenceWrite(t *testing.T) {
 
 	t.Run("gob gzipped", func(t *testing.T) {
 		tempFilePath := tempDir + ".gob.gz"
-		persist(tempFilePath, obj, true, "")
+		persistToFile(tempFilePath, obj, true, "")
 
 		// Check if the file exists.
 		_, err = os.Stat(tempFilePath)
@@ -123,7 +123,7 @@ func TestPersistenceRead(t *testing.T) {
 
 		// Read the file.
 		var res s
-		err = read(tempFilePath, &res, "")
+		err = readFromFile(tempFilePath, &res, "")
 		if err != nil {
 			t.Fatal("expected nil, got", err)
 		}
@@ -157,7 +157,7 @@ func TestPersistenceRead(t *testing.T) {
 
 		// Read the file.
 		var res s
-		err = read(tempFilePath, &res, "")
+		err = readFromFile(tempFilePath, &res, "")
 		if err != nil {
 			t.Fatal("expected nil, got", err)
 		}
@@ -207,7 +207,7 @@ func TestPersistenceEncryption(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			err := persist(tc.filePath, obj, tc.compress, encryptionKey)
+			err := persistToFile(tc.filePath, obj, tc.compress, encryptionKey)
 			if err != nil {
 				t.Fatal("expected nil, got", err)
 			}
@@ -220,7 +220,7 @@ func TestPersistenceEncryption(t *testing.T) {
 
 			// Read the file.
 			var res s
-			err = read(tc.filePath, &res, encryptionKey)
+			err = readFromFile(tc.filePath, &res, encryptionKey)
 			if err != nil {
 				t.Fatal("expected nil, got", err)
 			}


### PR DESCRIPTION
This PR adds `DB.ExportToWriter`, and implements the internal `persistToWriter`.

The import/read counterpart is https://github.com/philippgille/chromem-go/pull/72.

Both PRs combined address issue https://github.com/philippgille/chromem-go/issues/70.

Example code follows in https://github.com/philippgille/chromem-go/pull/73.