### PR TITLE
Import from io.Reader

### DIFF
--- a/db.go
+++ b/db.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -226,6 +227,61 @@ func (db *DB) Import(filePath string, encryptionKey string) error {
 	err = readFromFile(filePath, &persistenceDB, encryptionKey)
 	if err != nil {
 		return fmt.Errorf("couldn't read file: %w", err)
+	}
+
+	for _, pc := range persistenceDB.Collections {
+		c := &Collection{
+			Name: pc.Name,
+
+			metadata:  pc.Metadata,
+			documents: pc.Documents,
+		}
+		if db.persistDirectory != "" {
+			c.persistDirectory = filepath.Join(db.persistDirectory, hash2hex(pc.Name))
+			c.compress = db.compress
+		}
+		db.collections[c.Name] = c
+	}
+
+	return nil
+}
+
+// ImportFromReader imports the DB from a reader. The stream must be encoded as
+// gob and can optionally be compressed with flate (as gzip) and encrypted with
+// AES-GCM.
+// This works for both the in-memory and persistent DBs.
+// Existing collections are overwritten.
+// If the writer has to be closed, it's the caller's responsibility.
+//
+// - reader: An implementation of [io.ReadSeeker]
+// - encryptionKey: Optional, must be 32 bytes long if provided
+func (db *DB) ImportFromReader(reader io.ReadSeeker, encryptionKey string) error {
+	if encryptionKey != "" {
+		// AES 256 requires a 32 byte key
+		if len(encryptionKey) != 32 {
+			return errors.New("encryption key must be 32 bytes long")
+		}
+	}
+
+	// Create persistence structs with exported fields so that they can be decoded
+	// from gob.
+	type persistenceCollection struct {
+		Name      string
+		Metadata  map[string]string
+		Documents map[string]*Document
+	}
+	persistenceDB := struct {
+		Collections map[string]*persistenceCollection
+	}{
+		Collections: make(map[string]*persistenceCollection, len(db.collections)),
+	}
+
+	db.collectionsLock.Lock()
+	defer db.collectionsLock.Unlock()
+
+	err := readFromReader(reader, &persistenceDB, encryptionKey)
+	if err != nil {
+		return fmt.Errorf("couldn't read stream: %w", err)
 	}
 
 	for _, pc := range persistenceDB.Collections {

--- a/db.go
+++ b/db.go
@@ -142,7 +142,7 @@ func NewPersistentDB(path string, compress bool) (*DB, error) {
 					Name     string
 					Metadata map[string]string
 				}{}
-				err := read(fPath, &pc, "")
+				err := readFromFile(fPath, &pc, "")
 				if err != nil {
 					return nil, fmt.Errorf("couldn't read collection metadata: %w", err)
 				}
@@ -151,7 +151,7 @@ func NewPersistentDB(path string, compress bool) (*DB, error) {
 			} else if strings.HasSuffix(collectionDirEntry.Name(), ext) {
 				// Read document
 				d := &Document{}
-				err := read(fPath, d, "")
+				err := readFromFile(fPath, d, "")
 				if err != nil {
 					return nil, fmt.Errorf("couldn't read document: %w", err)
 				}
@@ -223,7 +223,7 @@ func (db *DB) Import(filePath string, encryptionKey string) error {
 	db.collectionsLock.Lock()
 	defer db.collectionsLock.Unlock()
 
-	err = read(filePath, &persistenceDB, encryptionKey)
+	err = readFromFile(filePath, &persistenceDB, encryptionKey)
 	if err != nil {
 		return fmt.Errorf("couldn't read file: %w", err)
 	}

--- a/db.go
+++ b/db.go
@@ -186,7 +186,21 @@ func NewPersistentDB(path string, compress bool) (*DB, error) {
 //
 // - filePath: Mandatory, must not be empty
 // - encryptionKey: Optional, must be 32 bytes long if provided
+//
+// Deprecated: Use [DB.ImportFromFile] instead.
 func (db *DB) Import(filePath string, encryptionKey string) error {
+	return db.ImportFromFile(filePath, encryptionKey)
+}
+
+// ImportFromFile imports the DB from a file at the given path. The file must be
+// encoded as gob and can optionally be compressed with flate (as gzip) and encrypted
+// with AES-GCM.
+// This works for both the in-memory and persistent DBs.
+// Existing collections are overwritten.
+//
+// - filePath: Mandatory, must not be empty
+// - encryptionKey: Optional, must be 32 bytes long if provided
+func (db *DB) ImportFromFile(filePath string, encryptionKey string) error {
 	if filePath == "" {
 		return fmt.Errorf("file path is empty")
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -147,7 +147,7 @@ func TestDB_ImportExport(t *testing.T) {
 			new := NewDB()
 
 			// Import
-			err = new.Import(tc.filePath, tc.encryptionKey)
+			err = new.ImportFromFile(tc.filePath, tc.encryptionKey)
 			if err != nil {
 				t.Fatal("expected no error, got", err)
 			}

--- a/persistence_test.go
+++ b/persistence_test.go
@@ -123,7 +123,7 @@ func TestPersistenceRead(t *testing.T) {
 
 		// Read the file.
 		var res s
-		err = read(tempFilePath, &res, "")
+		err = readFromFile(tempFilePath, &res, "")
 		if err != nil {
 			t.Fatal("expected nil, got", err)
 		}
@@ -157,7 +157,7 @@ func TestPersistenceRead(t *testing.T) {
 
 		// Read the file.
 		var res s
-		err = read(tempFilePath, &res, "")
+		err = readFromFile(tempFilePath, &res, "")
 		if err != nil {
 			t.Fatal("expected nil, got", err)
 		}
@@ -220,7 +220,7 @@ func TestPersistenceEncryption(t *testing.T) {
 
 			// Read the file.
 			var res s
-			err = read(tc.filePath, &res, encryptionKey)
+			err = readFromFile(tc.filePath, &res, encryptionKey)
 			if err != nil {
 				t.Fatal("expected nil, got", err)
 			}


### PR DESCRIPTION
This PR adds `DB.ImportFromReader`, and implements the internal `readFromReader`.

The export/writer counterpart is https://github.com/philippgille/chromem-go/pull/71.

Both PRs combined address issue https://github.com/philippgille/chromem-go/issues/70.

Example code follows in https://github.com/philippgille/chromem-go/pull/73.