### PR TITLE
Fix query embedding isn't normalized in Collection.QueryEmbedding() call

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -347,6 +347,7 @@ func (c *Collection) Query(ctx context.Context, queryText string, nResults int, 
 //
 //   - queryEmbedding: The embedding of the query to search for. It must be created
 //     with the same embedding model as the document embeddings in the collection.
+//     The embedding will be normalized if it's not the case yet.
 //   - nResults: The number of results to return. Must be > 0.
 //   - where: Conditional filtering on metadata. Optional.
 //   - whereDocument: Conditional filtering on documents. Optional.
@@ -380,6 +381,12 @@ func (c *Collection) QueryEmbedding(ctx context.Context, queryEmbedding []float3
 	// No need to continue if the filters got rid of all documents
 	if len(filteredDocs) == 0 {
 		return nil, nil
+	}
+
+	// Normalize embedding if not the case yet. We only support cosine similarity
+	// for now and all documents were already normalized when added to the collection.
+	if !isNormalized(queryEmbedding) {
+		queryEmbedding = normalizeVector(queryEmbedding)
 	}
 
 	// For the remaining documents, get the most similar docs.

--- a/collection_test.go
+++ b/collection_test.go
@@ -461,7 +461,6 @@ func TestCollection_Delete(t *testing.T) {
 
 	// Check number of files in the persist directory
 	d, err := os.ReadDir(c.persistDirectory)
-
 	if err != nil {
 		t.Fatal("expected nil, got", err)
 	}
@@ -507,7 +506,6 @@ func TestCollection_Delete(t *testing.T) {
 	}
 
 	checkCount(0)
-
 }
 
 // Global var for assignment in the benchmark to avoid compiler optimizations.
@@ -566,7 +564,7 @@ func benchmarkCollection_Query(b *testing.B, n int, withContent bool) {
 	for j := 0; j < d; j++ {
 		qv[j] = r.Float32()
 	}
-	// Most embeddings are normalized, so we normalize this one too
+	// The document embeddings are normalized, so the query must be normalized too.
 	qv = normalizeVector(qv)
 
 	// Create collection


### PR DESCRIPTION
For the `Collection.Query` call the embedding is created and normalized. For `Collection.QueryEmbedding()` the embedding is a parameter, and so far it was assumed/expected to be normalized by the user who calls the function, but that's not guaranteed, so now we check if the embedding is normalized and if it's not then we normalize it.

There's virtually no impact on query performance if the query was normalized already, so no need to extend the function with a boolean parameter to allow users to explicitly skip the check.

Here's a run on `main` branch:

<details><summary>Benchmark result</summary>

```
$ go test -benchmem -run=^$ -bench .
goos: linux
goarch: amd64
pkg: github.com/philippgille/chromem-go
cpu: 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
BenchmarkCollection_Query_NoContent_100-8      	   13202	     90541 ns/op	    5165 B/op	      95 allocs/op
BenchmarkCollection_Query_NoContent_1000-8     	    2181	    512950 ns/op	   13577 B/op	     141 allocs/op
BenchmarkCollection_Query_NoContent_5000-8     	     564	   2140110 ns/op	   47125 B/op	     174 allocs/op
BenchmarkCollection_Query_NoContent_25000-8    	     121	   9984625 ns/op	  211688 B/op	     203 allocs/op
BenchmarkCollection_Query_NoContent_100000-8   	      30	  39467498 ns/op	  810281 B/op	     228 allocs/op
BenchmarkCollection_Query_100-8                	   13039	     91023 ns/op	    5154 B/op	      94 allocs/op
BenchmarkCollection_Query_1000-8               	    2186	    517386 ns/op	   13564 B/op	     141 allocs/op
BenchmarkCollection_Query_5000-8               	     564	   2095981 ns/op	   47145 B/op	     175 allocs/op
BenchmarkCollection_Query_25000-8              	     100	  10031972 ns/op	  211669 B/op	     203 allocs/op
BenchmarkCollection_Query_100000-8             	      30	  39626423 ns/op	  810543 B/op	     238 allocs/op
PASS
ok  	github.com/philippgille/chromem-go	28.154s
```

</details>

Here's a run on this branch with the normalization check:

<details><summary>Benchmark result</summary>

```
$ go test -benchmem -run=^$ -bench .
goos: linux
goarch: amd64
pkg: github.com/philippgille/chromem-go
cpu: 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
BenchmarkCollection_Query_NoContent_100-8      	   13184	     90867 ns/op	    5143 B/op	      94 allocs/op
BenchmarkCollection_Query_NoContent_1000-8     	    2170	    513390 ns/op	   13578 B/op	     141 allocs/op
BenchmarkCollection_Query_NoContent_5000-8     	     562	   2130892 ns/op	   47115 B/op	     174 allocs/op
BenchmarkCollection_Query_NoContent_25000-8    	     100	  10010782 ns/op	  211756 B/op	     207 allocs/op
BenchmarkCollection_Query_NoContent_100000-8   	      30	  39342416 ns/op	  810356 B/op	     230 allocs/op
BenchmarkCollection_Query_100-8                	   13170	     90577 ns/op	    5165 B/op	      95 allocs/op
BenchmarkCollection_Query_1000-8               	    2151	    513987 ns/op	   13574 B/op	     141 allocs/op
BenchmarkCollection_Query_5000-8               	     558	   2114246 ns/op	   47109 B/op	     173 allocs/op
BenchmarkCollection_Query_25000-8              	     100	  10089708 ns/op	  211777 B/op	     208 allocs/op
BenchmarkCollection_Query_100000-8             	      30	  39509327 ns/op	  810383 B/op	     232 allocs/op
PASS
ok  	github.com/philippgille/chromem-go	26.538s
```

</details>

It looks even faster, which is just from regular fluctuation.