### PR TITLE
Fix test panic on unexpected pass

### DIFF
--- a/collection_test.go
+++ b/collection_test.go
@@ -382,7 +382,9 @@ func TestCollection_QueryError(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.query()
-			if err.Error() != tc.expErr {
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			} else if err.Error() != tc.expErr {
 				t.Fatal("expected", tc.expErr, "got", err)
 			}
 		})


### PR DESCRIPTION
In `TestCollection_QueryError`, when the query call doesn't return an error, the test panicked, instead of gracefully failing the test. This PR fixes that.