### PR TITLE
Make normalizeVector(v) in place

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -225,7 +225,7 @@ func (c *Collection) AddDocument(ctx context.Context, doc Document) error {
 		doc.Embedding = embedding
 	} else {
 		if !isNormalized(doc.Embedding) {
-			doc.Embedding = normalizeVector(doc.Embedding)
+			normalizeVector(doc.Embedding)
 		}
 	}
 
@@ -388,7 +388,7 @@ func (c *Collection) QueryEmbedding(ctx context.Context, queryEmbedding []float3
 	// Normalize embedding if not the case yet. We only support cosine similarity
 	// for now and all documents were already normalized when added to the collection.
 	if !isNormalized(queryEmbedding) {
-		queryEmbedding = normalizeVector(queryEmbedding)
+		normalizeVector(queryEmbedding)
 	}
 
 	// If the filtering already reduced the number of documents to fewer than nResults,

--- a/collection.go
+++ b/collection.go
@@ -225,7 +225,7 @@ func (c *Collection) AddDocument(ctx context.Context, doc Document) error {
 		doc.Embedding = embedding
 	} else {
 		if !isNormalized(doc.Embedding) {
-			normalizeVector(doc.Embedding)
+			normalizeVectorInPlace(doc.Embedding)
 		}
 	}
 
@@ -388,7 +388,7 @@ func (c *Collection) QueryEmbedding(ctx context.Context, queryEmbedding []float3
 	// Normalize embedding if not the case yet. We only support cosine similarity
 	// for now and all documents were already normalized when added to the collection.
 	if !isNormalized(queryEmbedding) {
-		normalizeVector(queryEmbedding)
+		queryEmbedding = normalizeVector(queryEmbedding)
 	}
 
 	// If the filtering already reduced the number of documents to fewer than nResults,

--- a/collection_test.go
+++ b/collection_test.go
@@ -567,7 +567,7 @@ func benchmarkCollection_Query(b *testing.B, n int, withContent bool) {
 		qv[j] = r.Float32()
 	}
 	// The document embeddings are normalized, so the query must be normalized too.
-	qv = normalizeVector(qv)
+	normalizeVector(qv)
 
 	// Create collection
 	db := NewDB()
@@ -590,7 +590,7 @@ func benchmarkCollection_Query(b *testing.B, n int, withContent bool) {
 		for j := 0; j < d; j++ {
 			v[j] = r.Float32()
 		}
-		v = normalizeVector(v)
+		normalizeVector(v)
 
 		// Add document with some metadata and content depending on parameter.
 		// When providing embeddings, the embedding func is not called.

--- a/collection_test.go
+++ b/collection_test.go
@@ -567,7 +567,7 @@ func benchmarkCollection_Query(b *testing.B, n int, withContent bool) {
 		qv[j] = r.Float32()
 	}
 	// The document embeddings are normalized, so the query must be normalized too.
-	normalizeVector(qv)
+	normalizeVectorInPlace(qv)
 
 	// Create collection
 	db := NewDB()
@@ -590,7 +590,7 @@ func benchmarkCollection_Query(b *testing.B, n int, withContent bool) {
 		for j := 0; j < d; j++ {
 			v[j] = r.Float32()
 		}
-		normalizeVector(v)
+		normalizeVectorInPlace(v)
 
 		// Add document with some metadata and content depending on parameter.
 		// When providing embeddings, the embedding func is not called.

--- a/embed_cohere.go
+++ b/embed_cohere.go
@@ -159,7 +159,7 @@ func NewEmbeddingFuncCohere(apiKey string, model EmbeddingModelCohere) Embedding
 			}
 		})
 		if !checkedNormalized {
-			v = normalizeVector(v)
+			normalizeVector(v)
 		}
 
 		return v, nil

--- a/embed_cohere.go
+++ b/embed_cohere.go
@@ -159,7 +159,7 @@ func NewEmbeddingFuncCohere(apiKey string, model EmbeddingModelCohere) Embedding
 			}
 		})
 		if !checkedNormalized {
-			normalizeVector(v)
+			normalizeVectorInPlace(v)
 		}
 
 		return v, nil

--- a/embed_ollama.go
+++ b/embed_ollama.go
@@ -91,7 +91,7 @@ func NewEmbeddingFuncOllama(model string, baseURLOllama string) EmbeddingFunc {
 			}
 		})
 		if !checkedNormalized {
-			normalizeVector(v)
+			normalizeVectorInPlace(v)
 		}
 
 		return v, nil

--- a/embed_ollama.go
+++ b/embed_ollama.go
@@ -91,7 +91,7 @@ func NewEmbeddingFuncOllama(model string, baseURLOllama string) EmbeddingFunc {
 			}
 		})
 		if !checkedNormalized {
-			v = normalizeVector(v)
+			normalizeVector(v)
 		}
 
 		return v, nil

--- a/embed_openai.go
+++ b/embed_openai.go
@@ -142,7 +142,8 @@ func newEmbeddingFuncOpenAICompat(baseURL, apiKey, model string, normalized *boo
 			if *normalized {
 				return v, nil
 			}
-			return normalizeVector(v), nil
+			normalizeVector(v)
+			return v, nil
 		}
 		checkNormalized.Do(func() {
 			if isNormalized(v) {
@@ -152,7 +153,7 @@ func newEmbeddingFuncOpenAICompat(baseURL, apiKey, model string, normalized *boo
 			}
 		})
 		if !checkedNormalized {
-			v = normalizeVector(v)
+			normalizeVector(v)
 		}
 
 		return v, nil

--- a/embed_openai.go
+++ b/embed_openai.go
@@ -142,7 +142,7 @@ func newEmbeddingFuncOpenAICompat(baseURL, apiKey, model string, normalized *boo
 			if *normalized {
 				return v, nil
 			}
-			normalizeVector(v)
+			normalizeVectorInPlace(v)
 			return v, nil
 		}
 		checkNormalized.Do(func() {
@@ -153,7 +153,7 @@ func newEmbeddingFuncOpenAICompat(baseURL, apiKey, model string, normalized *boo
 			}
 		})
 		if !checkedNormalized {
-			normalizeVector(v)
+			normalizeVectorInPlace(v)
 		}
 
 		return v, nil

--- a/vector.go
+++ b/vector.go
@@ -19,8 +19,8 @@ func cosineSimilarity(a, b []float32) (float32, error) {
 	}
 
 	if !isNormalized(a) || !isNormalized(b) {
-		normalizeVector(a)
-		normalizeVector(b)
+		a = normalizeVector(a)
+		b = normalizeVector(b)
 	}
 	dotProduct, err := dotProduct(a, b)
 	if err != nil {
@@ -50,7 +50,7 @@ func dotProduct(a, b []float32) (float32, error) {
 	return dotProduct, nil
 }
 
-func normalizeVector(v []float32) {
+func normalizeVectorInPlace(v []float32) {
 	var norm float32
 	for _, val := range v {
 		norm += val * val
@@ -60,6 +60,13 @@ func normalizeVector(v []float32) {
 	for i, val := range v {
 		v[i] = val / norm
 	}
+}
+
+func normalizeVector(v []float32) []float32 {
+	r := make([]float32, len(v))
+	copy(r, v)
+	normalizeVectorInPlace(r)
+	return r
 }
 
 // isNormalized checks if the vector is normalized.

--- a/vector.go
+++ b/vector.go
@@ -19,7 +19,8 @@ func cosineSimilarity(a, b []float32) (float32, error) {
 	}
 
 	if !isNormalized(a) || !isNormalized(b) {
-		a, b = normalizeVector(a), normalizeVector(b)
+		normalizeVector(a)
+		normalizeVector(b)
 	}
 	dotProduct, err := dotProduct(a, b)
 	if err != nil {
@@ -49,19 +50,16 @@ func dotProduct(a, b []float32) (float32, error) {
 	return dotProduct, nil
 }
 
-func normalizeVector(v []float32) []float32 {
+func normalizeVector(v []float32) {
 	var norm float32
 	for _, val := range v {
 		norm += val * val
 	}
 	norm = float32(math.Sqrt(float64(norm)))
 
-	res := make([]float32, len(v))
 	for i, val := range v {
-		res[i] = val / norm
+		v[i] = val / norm
 	}
-
-	return res
 }
 
 // isNormalized checks if the vector is normalized.


### PR DESCRIPTION
All usage of normalizeVector was in the form of
```go
    v = normalizeVector(v)
```
In that case it's better to just do the replacement in place and not having to allocate a new slice.