### PR TITLE
Fix link in Godoc

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -126,7 +126,7 @@ func newCollection(name string, metadata map[string]string, embed EmbeddingFunc,
 //     you can filter on this metadata. Optional.
 //   - contents: The contents to associate with the embeddings.
 //
-// This is a Chroma-like method. For a more Go-idiomatic one, see [AddDocuments].
+// This is a Chroma-like method. For a more Go-idiomatic one, see [Collection.AddDocuments].
 func (c *Collection) Add(ctx context.Context, ids []string, embeddings [][]float32, metadatas []map[string]string, contents []string) error {
 	return c.AddConcurrently(ctx, ids, embeddings, metadatas, contents, 1)
 }
@@ -135,7 +135,7 @@ func (c *Collection) Add(ctx context.Context, ids []string, embeddings [][]float
 // This is mostly useful when you don't pass any embeddings, so they have to be created.
 // Upon error, concurrently running operations are canceled and the error is returned.
 //
-// This is a Chroma-like method. For a more Go-idiomatic one, see [AddDocuments].
+// This is a Chroma-like method. For a more Go-idiomatic one, see [Collection.AddDocuments].
 func (c *Collection) AddConcurrently(ctx context.Context, ids []string, embeddings [][]float32, metadatas []map[string]string, contents []string, concurrency int) error {
 	if len(ids) == 0 {
 		return errors.New("ids are empty")


### PR DESCRIPTION
Previously the link was not rendered correctly (not clickable). Now it's fixed.

Tested with `pkgsite -open` for the local version of https://pkg.go.dev, then http://localhost:8080/github.com/philippgille/chromem-go#Collection.Add is:
![image](https://github.com/user-attachments/assets/2d58ca45-d8ac-4917-bda4-ff7947ba0613)
