### PR TITLE
Make Vertex options hybrid

### DIFF
--- a/embed_vertex.go
+++ b/embed_vertex.go
@@ -30,9 +30,9 @@ type vertexOptions struct {
 	autoTruncate bool
 }
 
-// NewVertexOptions creates a new vertexOptions struct with default values.
+// DefaultVertexOptions creates a new vertexOptions struct with default values.
 // Use the `With...()` methods to change them.
-func NewVertexOptions() *vertexOptions {
+func DefaultVertexOptions() *vertexOptions {
 	return &vertexOptions{
 		apiEndpoint:  baseURLVertex,
 		autoTruncate: false,
@@ -66,7 +66,7 @@ type vertexEmbeddings struct {
 // For the opts you can pass nil to use the default options.
 func NewEmbeddingFuncVertex(apiKey, project string, model EmbeddingModelVertex, opts *vertexOptions) EmbeddingFunc {
 	if opts == nil {
-		opts = NewVertexOptions()
+		opts = DefaultVertexOptions()
 	}
 
 	// We don't set a default timeout here, although it's usually a good idea.

--- a/embed_vertex.go
+++ b/embed_vertex.go
@@ -25,32 +25,26 @@ const (
 
 const baseURLVertex = "https://us-central1-aiplatform.googleapis.com/v1"
 
-type vertexConfig struct {
-	apiKey  string
-	project string
-	model   EmbeddingModelVertex
-
-	// Optional
+type vertexOptions struct {
 	apiEndpoint  string
 	autoTruncate bool
 }
 
-func NewVertexConfig(apiKey, project string, model EmbeddingModelVertex) *vertexConfig {
-	return &vertexConfig{
-		apiKey:       apiKey,
-		project:      project,
-		model:        model,
+// NewVertexOptions creates a new vertexOptions struct with default values.
+// Use the `With...()` methods to change them.
+func NewVertexOptions() *vertexOptions {
+	return &vertexOptions{
 		apiEndpoint:  baseURLVertex,
 		autoTruncate: false,
 	}
 }
 
-func (c *vertexConfig) WithAPIEndpoint(apiEndpoint string) *vertexConfig {
+func (c *vertexOptions) WithAPIEndpoint(apiEndpoint string) *vertexOptions {
 	c.apiEndpoint = apiEndpoint
 	return c
 }
 
-func (c *vertexConfig) WithAutoTruncate(autoTruncate bool) *vertexConfig {
+func (c *vertexOptions) WithAutoTruncate(autoTruncate bool) *vertexOptions {
 	c.autoTruncate = autoTruncate
 	return c
 }
@@ -68,7 +62,12 @@ type vertexEmbeddings struct {
 	// there's more here, but we only care about the embeddings
 }
 
-func NewEmbeddingFuncVertex(config *vertexConfig) EmbeddingFunc {
+// NewEmbeddingFuncVertex creates an EmbeddingFunc that uses the GCP Vertex API.
+// For the opts you can pass nil to use the default options.
+func NewEmbeddingFuncVertex(apiKey, project string, model EmbeddingModelVertex, opts *vertexOptions) EmbeddingFunc {
+	if opts == nil {
+		opts = NewVertexOptions()
+	}
 
 	// We don't set a default timeout here, although it's usually a good idea.
 	// In our case though, the library user can set the timeout on the context,
@@ -79,7 +78,6 @@ func NewEmbeddingFuncVertex(config *vertexConfig) EmbeddingFunc {
 	checkNormalized := sync.Once{}
 
 	return func(ctx context.Context, text string) ([]float32, error) {
-
 		b := map[string]any{
 			"instances": []map[string]any{
 				{
@@ -87,7 +85,7 @@ func NewEmbeddingFuncVertex(config *vertexConfig) EmbeddingFunc {
 				},
 			},
 			"parameters": map[string]any{
-				"autoTruncate": config.autoTruncate,
+				"autoTruncate": opts.autoTruncate,
 			},
 		}
 
@@ -97,7 +95,7 @@ func NewEmbeddingFuncVertex(config *vertexConfig) EmbeddingFunc {
 			return nil, fmt.Errorf("couldn't marshal request body: %w", err)
 		}
 
-		fullURL := fmt.Sprintf("%s/projects/%s/locations/us-central1/publishers/google/models/%s:predict", config.apiEndpoint, config.project, config.model)
+		fullURL := fmt.Sprintf("%s/projects/%s/locations/us-central1/publishers/google/models/%s:predict", opts.apiEndpoint, project, model)
 
 		// Create the request. Creating it with context is important for a timeout
 		// to be possible, because the client is configured without a timeout.
@@ -107,7 +105,7 @@ func NewEmbeddingFuncVertex(config *vertexConfig) EmbeddingFunc {
 		}
 		req.Header.Set("Accept", "application/json")
 		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", "Bearer "+config.apiKey)
+		req.Header.Set("Authorization", "Bearer "+apiKey)
 
 		// Send the request.
 		resp, err := client.Do(req)


### PR DESCRIPTION
As per https://github.com/philippgille/chromem-go/pull/91#issuecomment-2254526831, this PR is a suggestion to do kind of a hybrid for the options. We use mandatory parameters directly in the constructor function, but then instead of variadic functions we have one struct for optional configuration that can be adjusted with a fluent API (`opts.With...().With...()`).

Variadic functions are very popular and common in widely used libraries (e.g. grpc-go), and have the benefit of not requiring the last parameter in case you're fine with default values. Some downsides are that passing functions instead of a struct can be less intuitive (maybe just for Go newcomers), as well as that each `With` function for an optional option is then a global package member.

TBH I'm undecided which is best. This PR is just a suggestion and open for discussion.

The alternative is to revert to variadic functions, PR here: https://github.com/philippgille/chromem-go/pull/93