### PR TITLE
Use variadic functions for Vertex options

### DIFF
--- a/embed_vertex.go
+++ b/embed_vertex.go
@@ -25,34 +25,30 @@ const (
 
 const baseURLVertex = "https://us-central1-aiplatform.googleapis.com/v1"
 
-type vertexConfig struct {
-	apiKey  string
-	project string
-	model   EmbeddingModelVertex
-
-	// Optional
-	apiEndpoint  string
-	autoTruncate bool
+type VertexOptions struct {
+	APIEndpoint  string
+	AutoTruncate bool
 }
 
-func NewVertexConfig(apiKey, project string, model EmbeddingModelVertex) *vertexConfig {
-	return &vertexConfig{
-		apiKey:       apiKey,
-		project:      project,
-		model:        model,
-		apiEndpoint:  baseURLVertex,
-		autoTruncate: false,
+func DefaultVertexOptions() *VertexOptions {
+	return &VertexOptions{
+		APIEndpoint:  baseURLVertex,
+		AutoTruncate: false,
 	}
 }
 
-func (c *vertexConfig) WithAPIEndpoint(apiEndpoint string) *vertexConfig {
-	c.apiEndpoint = apiEndpoint
-	return c
+type VertexOption func(*VertexOptions)
+
+func WithVertexAPIEndpoint(apiEndpoint string) VertexOption {
+	return func(o *VertexOptions) {
+		o.APIEndpoint = apiEndpoint
+	}
 }
 
-func (c *vertexConfig) WithAutoTruncate(autoTruncate bool) *vertexConfig {
-	c.autoTruncate = autoTruncate
-	return c
+func WithVertexAutoTruncate(autoTruncate bool) VertexOption {
+	return func(o *VertexOptions) {
+		o.AutoTruncate = autoTruncate
+	}
 }
 
 type vertexResponse struct {
@@ -68,7 +64,16 @@ type vertexEmbeddings struct {
 	// there's more here, but we only care about the embeddings
 }
 
-func NewEmbeddingFuncVertex(config *vertexConfig) EmbeddingFunc {
+func NewEmbeddingFuncVertex(apiKey, project string, model EmbeddingModelVertex, opts ...VertexOption) EmbeddingFunc {
+
+	cfg := DefaultVertexOptions()
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	if cfg.APIEndpoint == "" {
+		cfg.APIEndpoint = baseURLVertex
+	}
 
 	// We don't set a default timeout here, although it's usually a good idea.
 	// In our case though, the library user can set the timeout on the context,
@@ -87,7 +92,7 @@ func NewEmbeddingFuncVertex(config *vertexConfig) EmbeddingFunc {
 				},
 			},
 			"parameters": map[string]any{
-				"autoTruncate": config.autoTruncate,
+				"autoTruncate": cfg.AutoTruncate,
 			},
 		}
 
@@ -97,7 +102,7 @@ func NewEmbeddingFuncVertex(config *vertexConfig) EmbeddingFunc {
 			return nil, fmt.Errorf("couldn't marshal request body: %w", err)
 		}
 
-		fullURL := fmt.Sprintf("%s/projects/%s/locations/us-central1/publishers/google/models/%s:predict", config.apiEndpoint, config.project, config.model)
+		fullURL := fmt.Sprintf("%s/projects/%s/locations/us-central1/publishers/google/models/%s:predict", cfg.APIEndpoint, project, model)
 
 		// Create the request. Creating it with context is important for a timeout
 		// to be possible, because the client is configured without a timeout.
@@ -107,7 +112,7 @@ func NewEmbeddingFuncVertex(config *vertexConfig) EmbeddingFunc {
 		}
 		req.Header.Set("Accept", "application/json")
 		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", "Bearer "+config.apiKey)
+		req.Header.Set("Authorization", "Bearer "+apiKey)
 
 		// Send the request.
 		resp, err := client.Do(req)

--- a/embed_vertex.go
+++ b/embed_vertex.go
@@ -25,29 +25,29 @@ const (
 
 const baseURLVertex = "https://us-central1-aiplatform.googleapis.com/v1"
 
-type VertexOptions struct {
-	APIEndpoint  string
-	AutoTruncate bool
+type vertexOptions struct {
+	apiEndpoint  string
+	autoTruncate bool
 }
 
-func DefaultVertexOptions() *VertexOptions {
-	return &VertexOptions{
-		APIEndpoint:  baseURLVertex,
-		AutoTruncate: false,
+func defaultVertexOptions() *vertexOptions {
+	return &vertexOptions{
+		apiEndpoint:  baseURLVertex,
+		autoTruncate: false,
 	}
 }
 
-type VertexOption func(*VertexOptions)
+type VertexOption func(*vertexOptions)
 
 func WithVertexAPIEndpoint(apiEndpoint string) VertexOption {
-	return func(o *VertexOptions) {
-		o.APIEndpoint = apiEndpoint
+	return func(o *vertexOptions) {
+		o.apiEndpoint = apiEndpoint
 	}
 }
 
 func WithVertexAutoTruncate(autoTruncate bool) VertexOption {
-	return func(o *VertexOptions) {
-		o.AutoTruncate = autoTruncate
+	return func(o *vertexOptions) {
+		o.autoTruncate = autoTruncate
 	}
 }
 
@@ -65,14 +65,13 @@ type vertexEmbeddings struct {
 }
 
 func NewEmbeddingFuncVertex(apiKey, project string, model EmbeddingModelVertex, opts ...VertexOption) EmbeddingFunc {
-
-	cfg := DefaultVertexOptions()
+	cfg := defaultVertexOptions()
 	for _, opt := range opts {
 		opt(cfg)
 	}
 
-	if cfg.APIEndpoint == "" {
-		cfg.APIEndpoint = baseURLVertex
+	if cfg.apiEndpoint == "" {
+		cfg.apiEndpoint = baseURLVertex
 	}
 
 	// We don't set a default timeout here, although it's usually a good idea.
@@ -84,7 +83,6 @@ func NewEmbeddingFuncVertex(apiKey, project string, model EmbeddingModelVertex, 
 	checkNormalized := sync.Once{}
 
 	return func(ctx context.Context, text string) ([]float32, error) {
-
 		b := map[string]any{
 			"instances": []map[string]any{
 				{
@@ -92,7 +90,7 @@ func NewEmbeddingFuncVertex(apiKey, project string, model EmbeddingModelVertex, 
 				},
 			},
 			"parameters": map[string]any{
-				"autoTruncate": cfg.AutoTruncate,
+				"autoTruncate": cfg.autoTruncate,
 			},
 		}
 
@@ -102,7 +100,7 @@ func NewEmbeddingFuncVertex(apiKey, project string, model EmbeddingModelVertex, 
 			return nil, fmt.Errorf("couldn't marshal request body: %w", err)
 		}
 
-		fullURL := fmt.Sprintf("%s/projects/%s/locations/us-central1/publishers/google/models/%s:predict", cfg.APIEndpoint, project, model)
+		fullURL := fmt.Sprintf("%s/projects/%s/locations/us-central1/publishers/google/models/%s:predict", cfg.apiEndpoint, project, model)
 
 		// Create the request. Creating it with context is important for a timeout
 		// to be possible, because the client is configured without a timeout.


### PR DESCRIPTION
This reverts commit a146ce68fefdbabba983c2bb4acf97c435956de4, but also makes `VertexOptions` and `DefaultVertexOptions()` private/unexported.

It's an alternative to PR https://github.com/philippgille/chromem-go/pull/92