### PR TITLE
Add ListIDs to collection for querying all existing document IDs

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -292,6 +292,19 @@ func (c *Collection) AddDocument(ctx context.Context, doc Document) error {
 	return nil
 }
 
+// ListIDs returns the IDs of all documents in the collection.
+func (c *Collection) ListIDs(_ context.Context) []string {
+	c.documentsLock.RLock()
+	defer c.documentsLock.RUnlock()
+
+	ids := make([]string, 0, len(c.documents))
+	for id := range c.documents {
+		ids = append(ids, id)
+	}
+
+	return ids
+}
+
 // GetByID returns a document by its ID.
 // The returned document is a copy of the original document, so it can be safely
 // modified without affecting the collection.


### PR DESCRIPTION
In my app, I am creating documents based on markdown files.  I need to be able to update the DB when specific files change, and prune documents based on those markdown files being deleted.  This functionality helps me with that.

Additionally, this closes #103.