### PR TITLE
implement GetAllDocuments()

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -317,6 +317,20 @@ func (c *Collection) GetByID(ctx context.Context, id string) (Document, error) {
 	return Document{}, fmt.Errorf("document with ID '%v' not found", id)
 }
 
+// ListDocuments returns all documents in the collection.
+// The returned documents are a copy of the original documents, so they can be safely
+// modified without affecting the collection.
+func (c *Collection) ListDocuments() ([]Document, error) {
+	c.documentsLock.RLock()
+	defer c.documentsLock.RUnlock()
+
+	docs := make([]Document, 0, len(c.documents))
+	for _, doc := range c.documents {
+		docs = append(docs, *doc)
+	}
+	return docs, nil
+}
+
 // Delete removes document(s) from the collection.
 //
 //   - where: Conditional filtering on metadata. Optional.
@@ -543,20 +557,6 @@ func (c *Collection) queryEmbedding(ctx context.Context, queryEmbedding, negativ
 	}
 
 	return res, nil
-}
-
-// GetAllDocuments returns all documents in the collection.
-// The returned documents are a copy of the original documents, so they can be safely
-// modified without affecting the collection.
-func (c *Collection) GetAllDocuments() ([]Document, error) {
-	c.documentsLock.RLock()
-	defer c.documentsLock.RUnlock()
-
-	docs := make([]Document, 0, len(c.documents))
-	for _, doc := range c.documents {
-		docs = append(docs, *doc)
-	}
-	return docs, nil
 }
 
 // getDocPath generates the path to the document file.

--- a/collection_test.go
+++ b/collection_test.go
@@ -477,6 +477,40 @@ func TestCollection_Count(t *testing.T) {
 	}
 }
 
+func TestCollection_ListDocuments(t *testing.T) {
+	// Create collection
+	db := NewDB()
+	name := "test"
+	metadata := map[string]string{"foo": "bar"}
+	vectors := []float32{-0.40824828, 0.40824828, 0.81649655} // normalized version of `{-0.1, 0.1, 0.2}`
+	embeddingFunc := func(_ context.Context, _ string) ([]float32, error) {
+		return vectors, nil
+	}
+	c, _ := db.CreateCollection(name, metadata, embeddingFunc)
+
+	// Add documents
+	ids := []string{"1", "2", "3", "4"}
+	metadatas := []map[string]string{{"foo": "bar"}, {"a": "b"}, {"foo": "bar"}, {"e": "f"}}
+	contents := []string{"hello world", "hallo welt", "bonjour le monde", "hola mundo"}
+	c.Add(context.Background(), ids, nil, metadatas, contents)
+
+	// Get all documents
+	docs, err := c.ListDocuments()
+	if err != nil {
+		t.Fatal("expected nil, got", err)
+	}
+	if len(docs) != 4 {
+		t.Fatal("expected 4 documents, got", len(docs))
+	}
+
+	// since the documents are returned in a random order, we just check if there is a document with the content "hello world"
+	for _, doc := range docs {
+		if doc.Content == "hello world" {
+			break
+		}
+	}
+}
+
 func TestCollection_Delete(t *testing.T) {
 	// Create persistent collection
 	tmpdir, err := os.MkdirTemp(os.TempDir(), "chromem-test-*")
@@ -562,40 +596,6 @@ func TestCollection_Delete(t *testing.T) {
 	}
 
 	checkCount(0)
-}
-
-func TestCollection_GetAllDocuments(t *testing.T) {
-	// Create collection
-	db := NewDB()
-	name := "test"
-	metadata := map[string]string{"foo": "bar"}
-	vectors := []float32{-0.40824828, 0.40824828, 0.81649655} // normalized version of `{-0.1, 0.1, 0.2}`
-	embeddingFunc := func(_ context.Context, _ string) ([]float32, error) {
-		return vectors, nil
-	}
-	c, _ := db.CreateCollection(name, metadata, embeddingFunc)
-
-	// Add documents
-	ids := []string{"1", "2", "3", "4"}
-	metadatas := []map[string]string{{"foo": "bar"}, {"a": "b"}, {"foo": "bar"}, {"e": "f"}}
-	contents := []string{"hello world", "hallo welt", "bonjour le monde", "hola mundo"}
-	c.Add(context.Background(), ids, nil, metadatas, contents)
-
-	// Get all documents
-	docs, err := c.GetAllDocuments()
-	if err != nil {
-		t.Fatal("expected nil, got", err)
-	}
-	if len(docs) != 4 {
-		t.Fatal("expected 4 documents, got", len(docs))
-	}
-
-	// since the documents are returned in a random order, we just check if there is a document with the content "hello world"
-	for _, doc := range docs {
-		if doc.Content == "hello world" {
-			break
-		}
-	}
 }
 
 // Global var for assignment in the benchmark to avoid compiler optimizations.


### PR DESCRIPTION
Hey @philippgille, thanks for this great package!

I've had a hard time finding out that there is no possibility to kinda merge 2 existing collections. I appreciate your focus on staying as a simple package (as I've read in other Issues and Pull requests), so I avoided to extend the Import[..]() functions with `enableMerge` attributes - but instead implemented the simplest approach I could come up with: getting all existing documents of a collection. This way the end-user (or -developer?) is at least able to fetch all documents and import them into another collection on their own way.

I'm interested in your feedback and leave behind some happy greetings from Hamburg