### PR TITLE
Add gemini-embedding-001

### DIFF
--- a/embed_vertex.go
+++ b/embed_vertex.go
@@ -22,7 +22,7 @@ const (
 	EmbeddingModelVertexMultilingualV1 EmbeddingModelVertex = "textembedding-gecko-multilingual@001"
 	EmbeddingModelVertexMultilingualV2 EmbeddingModelVertex = "text-multilingual-embedding-002"
 
-	EmbeddingModelVertexGeminiv1 EmbeddingModelVertex = "gemini-embedding-001"
+	EmbeddingModelVertexGeminiV1 EmbeddingModelVertex = "gemini-embedding-001"
 )
 
 const baseURLVertex = "https://us-central1-aiplatform.googleapis.com/v1"


### PR DESCRIPTION
This PR adds support for the new gemini-embedding-001 model to the Vertex AI embedding
provider. This model is the latest generation for text embeddings and is recommended for use.

This change introduces a new constant, EmbeddingModelVertexGeminiV1, to the list of available
embedding models.

For more information, see the official documentation: Google AI for Developers 
(https://ai.google.dev/gemini-api/docs/models#gemini-embedding)