### PR TITLE
Update GitHub Actions workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # We make use of the `slices` feature, only available in 1.21 and newer
-        go-version: [ '1.21', '1.22', '1.23' ]
+        go-version: [ '1.23', '1.24' ]
 
     steps:
     - uses: actions/checkout@v4
@@ -26,9 +26,9 @@ jobs:
         go-version: ${{ matrix.go-version }}
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v8
       with:
-        version: v1.60.3
+        version: v2.2.2
         args: --verbose
 
   build:
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         # We make use of the `slices` feature, only available in 1.21 and newer
-        go-version: [ '1.21', '1.22', '1.23' ]
+        go-version: [ '1.23', '1.24' ]
 
     steps:
     - uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         # We make use of the `slices` feature, only available in 1.21 and newer
-        go-version: [ '1.21', '1.22', '1.23' ]
+        go-version: [ '1.23', '1.24' ]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
- Remove old Go versions
- Add new Go versions
- Update golangci-lint action
- Update golangci-lint version