### PR TITLE
2 additional methods to help with managing of collections: GetAllDocuments & GetDocumentsByMetadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 # Go workspace file
 go.work
+
+# IntelliJ
+.idea/

--- a/collection.go
+++ b/collection.go
@@ -558,7 +558,7 @@ func (c *Collection) queryEmbedding(ctx context.Context, queryEmbedding, negativ
 	return res, nil
 }
 
-func (c *Collection) GetAllDocuments(_ context.Context) ([]Document, error) {
+func (c *Collection) GetAllDocuments(_ context.Context, fetchDeep bool) ([]Document, error) {
 	c.documentsLock.RLock()
 	defer c.documentsLock.RUnlock()
 
@@ -566,8 +566,13 @@ func (c *Collection) GetAllDocuments(_ context.Context) ([]Document, error) {
 	for _, doc := range c.documents {
 		// Clone the document to avoid concurrent modification by reading goroutine
 		docCopy := *doc
-		docCopy.Metadata = maps.Clone(doc.Metadata)
-		docCopy.Embedding = slices.Clone(doc.Embedding)
+		if fetchDeep {
+			docCopy.Metadata = maps.Clone(doc.Metadata)
+			docCopy.Embedding = slices.Clone(doc.Embedding)
+		} else {
+			docCopy.Metadata = nil
+			docCopy.Embedding = nil
+		}
 		results = append(results, docCopy)
 	}
 	return results, nil

--- a/collection.go
+++ b/collection.go
@@ -558,7 +558,22 @@ func (c *Collection) queryEmbedding(ctx context.Context, queryEmbedding, negativ
 	return res, nil
 }
 
-func (c *Collection) GetDocumentsByMetadata(ctx context.Context, where map[string]string) ([]Document, error) {
+func (c *Collection) GetAllDocuments(_ context.Context) ([]Document, error) {
+	c.documentsLock.RLock()
+	defer c.documentsLock.RUnlock()
+
+	results := make([]Document, 0, len(c.documents))
+	for _, doc := range c.documents {
+		// Clone the document to avoid concurrent modification by reading goroutine
+		docCopy := *doc
+		docCopy.Metadata = maps.Clone(doc.Metadata)
+		docCopy.Embedding = slices.Clone(doc.Embedding)
+		results = append(results, docCopy)
+	}
+	return results, nil
+}
+
+func (c *Collection) GetDocumentsByMetadata(_ context.Context, where map[string]string) ([]Document, error) {
 	c.documentsLock.RLock()
 	defer c.documentsLock.RUnlock()
 


### PR DESCRIPTION
Hi, I am using chromem-go as the RAG engine in my gaming agent project; to enable dynamic actions, character memory and basic management of RAG data for users.

I added 2 methods to my fork which might be useful to be added to the main branch.
- `GetAllDocuments`: Simple as it sounds. Returns all documents in a collection. Has an option for deep fetching, which includes metadata and embeddings. If it's set to false, it will do shallow fetching with only ID and content string.
- `GetDocumentsByMetadata`: Fetches all documents in a collection which match one or more tags without performing a similarity search like `Query`. I use it to sync with an external source of truth, e.g. if actions get added / dropped or changed on game side, so my application always is in sync when performing queries.

I didn't do any performance testing (yet), so I don't know how this behaves on a larger scale.