### PR TITLE
Fix comment: Collection–Document is 1:n (not n:n)

### DIFF
--- a/db.go
+++ b/db.go
@@ -23,7 +23,7 @@ type EmbeddingFunc func(ctx context.Context, text string) ([]float32, error)
 
 // DB is the chromem-go database. It holds collections, which hold documents.
 //
-//	+----+    1-n    +------------+    n-n    +----------+
+//	+----+    1-n    +------------+    1-n    +----------+
 //	| DB |-----------| Collection |-----------| Document |
 //	+----+           +------------+           +----------+
 type DB struct {


### PR DESCRIPTION
Hey @philippgille, thanks for the great package!

From reading the code, it looks like each `Collection` stores its own `documents map[string]*Document` without cross-collection sharing. If I understood correctly, the relation is 1:n rather than n:n.

This PR proposes updating the diagram comment in `db.go` to reflect 1:n. If I'm missing context or there's a reason for n:n, I'm happy to adjust or close. Thanks for taking a look!