### PR TITLE
feat: Add similarity threshold filtering for queries (#107)

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -67,6 +67,14 @@ type QueryOptions struct {
 	// Conditional filtering on documents.
 	WhereDocument map[string]string
 
+	// Threshold is the minimum similarity threshold for results.
+	// Only documents with a similarity score greater than or equal to this value
+	// will be included in the results. Valid range is [0, 1].
+	// A value of 0 (default) disables threshold filtering and returns all results
+	// up to nResults.
+	// Example: A threshold of 0.7 means only documents with >= 70% similarity will be returned.
+	Threshold float32
+
 	// Negative is the negative query options.
 	// They can be used to exclude certain results from the query.
 	Negative NegativeQueryOptions
@@ -536,7 +544,7 @@ func (c *Collection) QueryWithOptions(ctx context.Context, options QueryOptions)
 		}
 	}
 
-	result, err := c.queryEmbedding(ctx, queryVector, negativeVector, negativeFilterThreshold, options.NResults, options.Where, options.WhereDocument)
+	result, err := c.queryEmbedding(ctx, queryVector, negativeVector, negativeFilterThreshold, options.NResults, options.Where, options.WhereDocument, options.Threshold)
 	if err != nil {
 		return nil, err
 	}
@@ -554,16 +562,19 @@ func (c *Collection) QueryWithOptions(ctx context.Context, options QueryOptions)
 //   - where: Conditional filtering on metadata. Optional.
 //   - whereDocument: Conditional filtering on documents. Optional.
 func (c *Collection) QueryEmbedding(ctx context.Context, queryEmbedding []float32, nResults int, where, whereDocument map[string]string) ([]Result, error) {
-	return c.queryEmbedding(ctx, queryEmbedding, nil, 0, nResults, where, whereDocument)
+	return c.queryEmbedding(ctx, queryEmbedding, nil, 0, nResults, where, whereDocument, 0)
 }
 
 // queryEmbedding performs an exhaustive nearest neighbor search on the collection.
-func (c *Collection) queryEmbedding(ctx context.Context, queryEmbedding, negativeEmbeddings []float32, negativeFilterThreshold float32, nResults int, where, whereDocument map[string]string) ([]Result, error) {
+func (c *Collection) queryEmbedding(ctx context.Context, queryEmbedding, negativeEmbeddings []float32, negativeFilterThreshold float32, nResults int, where, whereDocument map[string]string, threshold float32) ([]Result, error) {
 	if len(queryEmbedding) == 0 {
 		return nil, errors.New("queryEmbedding is empty")
 	}
 	if nResults <= 0 {
 		return nil, errors.New("nResults must be > 0")
+	}
+	if threshold < 0 || threshold > 1 {
+		return nil, errors.New("threshold must be between 0 and 1")
 	}
 	c.documentsLock.RLock()
 	defer c.documentsLock.RUnlock()
@@ -604,7 +615,7 @@ func (c *Collection) queryEmbedding(ctx context.Context, queryEmbedding, negativ
 	}
 
 	// For the remaining documents, get the most similar docs.
-	nMaxDocs, err := getMostSimilarDocs(ctx, queryEmbedding, negativeEmbeddings, negativeFilterThreshold, filteredDocs, resLen)
+	nMaxDocs, err := getMostSimilarDocs(ctx, queryEmbedding, negativeEmbeddings, negativeFilterThreshold, filteredDocs, resLen, threshold)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get most similar docs: %w", err)
 	}

--- a/query.go
+++ b/query.go
@@ -162,7 +162,7 @@ func documentMatchesFilters(document *Document, where, whereDocument map[string]
 	return true
 }
 
-func getMostSimilarDocs(ctx context.Context, queryVectors, negativeVector []float32, negativeFilterThreshold float32, docs []*Document, n int) ([]docSim, error) {
+func getMostSimilarDocs(ctx context.Context, queryVectors, negativeVector []float32, negativeFilterThreshold float32, docs []*Document, n int, threshold float32) ([]docSim, error) {
 	nMaxDocs := newMaxDocSims(n)
 
 	// Determine concurrency. Use number of docs or CPUs, whichever is smaller.
@@ -228,6 +228,12 @@ func getMostSimilarDocs(ctx context.Context, queryVectors, negativeVector []floa
 					if nsim > negativeFilterThreshold {
 						continue
 					}
+				}
+
+				// Apply threshold filter if specified
+				// Documents with similarity below threshold are skipped
+				if threshold > 0 && sim < threshold {
+					continue
 				}
 
 				nMaxDocs.add(docSim{docID: doc.ID, similarity: sim})

--- a/query_test.go
+++ b/query_test.go
@@ -196,3 +196,142 @@ func TestNegative(t *testing.T) {
 		}
 	})
 }
+
+func TestThreshold(t *testing.T) {
+	ctx := context.Background()
+	db := NewDB()
+
+	c, err := db.CreateCollection("test-threshold", nil, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	// Add test documents with known embeddings
+	if err := c.AddDocuments(ctx, []Document{
+		{
+			ID:        "high-similarity",
+			Embedding: []float32{0.9, 0.1, 0.1}, // Similar to query
+		},
+		{
+			ID:        "medium-similarity",
+			Embedding: []float32{0.5, 0.5, 0.5}, // Medium similarity
+		},
+		{
+			ID:        "low-similarity",
+			Embedding: []float32{0.1, 0.9, 0.1}, // Low similarity
+		},
+	}, 1); err != nil {
+		t.Fatalf("failed to add documents: %v", err)
+	}
+
+	query := []float32{0.8, 0.2, 0.2}
+
+	t.Run("threshold filters low similarity", func(t *testing.T) {
+		res, err := c.QueryWithOptions(ctx, QueryOptions{
+			QueryEmbedding: query,
+			NResults:       c.Count(), // Use actual count
+			Threshold:      0.85,      // Only return documents with >= 0.85 similarity
+		})
+		if err != nil {
+			t.Fatalf("query failed: %v", err)
+		}
+
+		// Should only return high-similarity document
+		if len(res) != 1 {
+			t.Fatalf("expected 1 result with threshold 0.85, got %d", len(res))
+		}
+
+		if res[0].ID != "high-similarity" {
+			t.Errorf("expected high-similarity document, got %s", res[0].ID)
+		}
+	})
+
+	t.Run("threshold 0 returns all results", func(t *testing.T) {
+		res, err := c.QueryWithOptions(ctx, QueryOptions{
+			QueryEmbedding: query,
+			NResults:       c.Count(), // Use actual count
+			Threshold:      0,         // No threshold
+		})
+		if err != nil {
+			t.Fatalf("query failed: %v", err)
+		}
+
+		// Should return all 3 documents
+		if len(res) != 3 {
+			t.Fatalf("expected 3 results with threshold 0, got %d", len(res))
+		}
+	})
+
+	t.Run("high threshold returns no results", func(t *testing.T) {
+		res, err := c.QueryWithOptions(ctx, QueryOptions{
+			QueryEmbedding: query,
+			NResults:       c.Count(), // Use actual count
+			Threshold:      0.99,      // Very high threshold (higher than 0.98)
+		})
+		if err != nil {
+			t.Fatalf("query failed: %v", err)
+		}
+
+		// Should return no documents
+		if len(res) != 0 {
+			t.Errorf("expected 0 results with threshold 0.99, got %d", len(res))
+		}
+	})
+
+	t.Run("threshold with nResults limit", func(t *testing.T) {
+		// Add more documents to test nResults limit
+		if err := c.AddDocuments(ctx, []Document{
+			{
+				ID:        "another-high",
+				Embedding: []float32{0.85, 0.15, 0.15},
+			},
+			{
+				ID:        "another-medium",
+				Embedding: []float32{0.45, 0.45, 0.45},
+			},
+		}, 1); err != nil {
+			t.Fatalf("failed to add more documents: %v", err)
+		}
+
+		res, err := c.QueryWithOptions(ctx, QueryOptions{
+			QueryEmbedding: query,
+			NResults:       2,   // Only return top 2
+			Threshold:      0.4, // But only those with >= 0.4 similarity
+		})
+		if err != nil {
+			t.Fatalf("query failed: %v", err)
+		}
+
+		// Should return at most 2 results, but both must meet threshold
+		if len(res) > 2 {
+			t.Errorf("expected at most 2 results, got %d", len(res))
+		}
+
+		// Verify all results meet threshold
+		for _, r := range res {
+			if r.Similarity < 0.4 {
+				t.Errorf("result %s has similarity %v below threshold 0.4", r.ID, r.Similarity)
+			}
+		}
+	})
+
+	t.Run("invalid threshold returns error", func(t *testing.T) {
+		_, err := c.QueryWithOptions(ctx, QueryOptions{
+			QueryEmbedding: query,
+			NResults:       1,
+			Threshold:      -0.5, // Invalid threshold
+		})
+		if err == nil {
+			t.Error("expected error for negative threshold")
+		}
+
+		_, err = c.QueryWithOptions(ctx, QueryOptions{
+			QueryEmbedding: query,
+			NResults:       1,
+			Threshold:      1.5, // Invalid threshold
+		})
+		if err == nil {
+			t.Error("expected error for threshold > 1")
+		}
+	})
+}


### PR DESCRIPTION

This PR implements similarity threshold filtering for queries, allowing users to retrieve documents based on similarity quality rather than just quantity (Issue #107).

Problem
Currently, users can only specify nResults (number of results to return). This means you always get exactly N results, even if some have very low similarity scores.

Solution
Added a Threshold field to QueryOptions that filters results by minimum similarity score:
- Range: [0, 1] (0 disables filtering)
- Only documents with similarity >= threshold are returned
- Combined with nResults for maximum results to consider



Usage Examples
// Query with threshold - only return highly similar documents
results, err := collection.QueryWithOptions(ctx, QueryOptions{
    QueryText:   "search text",
    NResults:    100,    // Maximum to consider
    Threshold:   0.7,    // Only return >= 70% similar
})
// Works with embeddings too
results, err := collection.QueryWithOptions(ctx, QueryOptions{
    QueryEmbedding: embedding,
    NResults:       100,
    Threshold:      0.7,
})

Behavior
- Threshold = 0 (default): Returns all results up to nResults (backward compatible)
- Threshold > 0: Only returns documents with similarity >= threshold
- Invalid thresholds (negative or > 1): Returns error
Testing
- All existing tests pass (backward compatibility verified)
- New tests added for:
  - Threshold filters low similarity documents
  - Threshold 0 returns all results
  - High threshold returns no results
  - Threshold combined with nResults limit
  - Invalid threshold validation
- Race detection enabled - no issues found

Benefits
1. Quality Control: Only return highly relevant results
2. Dynamic Filtering: Adjust threshold based on use case
3. Backward Compatible: Existing code works without changes