### PR TITLE
`persistence`: add pluggable compression codecs

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,10 @@ For the full interface see the Godoc: <https://pkg.go.dev/github.com/philippgill
   - [X] Metadata filters: Exact matches
 - Storage:
   - [X] In-memory
-  - [X] Optional immediate persistence (writes one file for each added collection and document, encoded as [gob](https://go.dev/blog/gob), optionally gzip-compressed)
-  - [X] Backups: Export and import of the entire DB to/from a single file (encoded as [gob](https://go.dev/blog/gob), optionally gzip-compressed and AES-GCM encrypted)
+  - [X] Optional immediate persistence (writes one file for each added collection and document, encoded as [gob](https://go.dev/blog/gob), optionally gzip-compressed or compressed with a registered custom codec)
+  - [X] Backups: Export and import of the entire DB to/from a single file (encoded as [gob](https://go.dev/blog/gob), optionally gzip-compressed or compressed with a registered custom codec, and AES-GCM encrypted)
     - Includes methods for generic `io.Writer`/`io.Reader` so you can plug S3 buckets and other blob storage, see [examples/s3-export-import](examples/s3-export-import) for example code
+    - Plug a custom codec (e.g. zstd) by calling `chromem.RegisterCompression("zstd", chromem.CompressionCodec{Extension: ".zst", MagicNumber: []byte{0x28, 0xb5, 0x2f, 0xfd}, NewWriter: ..., NewReader: ...})`, then pass the registered name to `NewPersistentDBWithCompression` / `ExportTo*WithCompression` / `ImportFrom*WithCompression`
 - Data types:
   - [X] Documents (text)
 

--- a/README.md
+++ b/README.md
@@ -159,10 +159,9 @@ For the full interface see the Godoc: <https://pkg.go.dev/github.com/philippgill
   - [X] Metadata filters: Exact matches
 - Storage:
   - [X] In-memory
-  - [X] Optional immediate persistence (writes one file for each added collection and document, encoded as [gob](https://go.dev/blog/gob), optionally gzip-compressed or compressed with a registered custom codec)
-  - [X] Backups: Export and import of the entire DB to/from a single file (encoded as [gob](https://go.dev/blog/gob), optionally gzip-compressed or compressed with a registered custom codec, and AES-GCM encrypted)
+  - [X] Optional immediate persistence (writes one file for each added collection and document, encoded as [gob](https://go.dev/blog/gob), optionally gzip-compressed)
+  - [X] Backups: Export and import of the entire DB to/from a single file (encoded as [gob](https://go.dev/blog/gob), optionally gzip-compressed and AES-GCM encrypted)
     - Includes methods for generic `io.Writer`/`io.Reader` so you can plug S3 buckets and other blob storage, see [examples/s3-export-import](examples/s3-export-import) for example code
-    - Plug a custom codec (e.g. zstd) by calling `chromem.RegisterCompression("zstd", chromem.CompressionCodec{Extension: ".zst", MagicNumber: []byte{0x28, 0xb5, 0x2f, 0xfd}, NewWriter: ..., NewReader: ...})`, then pass the registered name to `NewPersistentDBWithCompression` / `ExportTo*WithCompression` / `ImportFrom*WithCompression`
 - Data types:
   - [X] Documents (text)
 

--- a/collection.go
+++ b/collection.go
@@ -22,7 +22,7 @@ type Collection struct {
 	embed         EmbeddingFunc
 
 	persistDirectory string
-	compress         bool
+	compression      Compression
 
 	// ⚠️ When adding fields here, consider adding them to the persistence struct
 	// versions in [DB.Export] and [DB.Import] as well!
@@ -91,7 +91,7 @@ type NegativeQueryOptions struct {
 
 // We don't export this yet to keep the API surface to the bare minimum.
 // Users create collections via [Client.CreateCollection].
-func newCollection(name string, metadata map[string]string, embed EmbeddingFunc, dbDir string, compress bool) (*Collection, error) {
+func newCollection(name string, metadata map[string]string, embed EmbeddingFunc, dbDir string, compression Compression) (*Collection, error) {
 	// We copy the metadata to avoid data races in case the caller modifies the
 	// map after creating the collection while we range over it.
 	m := make(map[string]string, len(metadata))
@@ -111,7 +111,7 @@ func newCollection(name string, metadata map[string]string, embed EmbeddingFunc,
 	if dbDir != "" {
 		safeName := hash2hex(name)
 		c.persistDirectory = filepath.Join(dbDir, safeName)
-		c.compress = compress
+		c.compression = compression
 		return c, c.persistMetadata()
 	}
 
@@ -282,8 +282,11 @@ func (c *Collection) AddDocument(ctx context.Context, doc Document) error {
 
 	// Persist the document
 	if c.persistDirectory != "" {
-		docPath := c.getDocPath(doc.ID)
-		err := persistToFile(docPath, doc, c.compress, "")
+		docPath, err := c.getDocPath(doc.ID)
+		if err != nil {
+			return fmt.Errorf("couldn't determine document path: %w", err)
+		}
+		err = persistToFileWithCompression(docPath, doc, c.compression, "")
 		if err != nil {
 			return fmt.Errorf("couldn't persist document to %q: %w", docPath, err)
 		}
@@ -441,8 +444,11 @@ func (c *Collection) Delete(_ context.Context, where, whereDocument map[string]s
 
 		// Remove the document from disk
 		if c.persistDirectory != "" {
-			docPath := c.getDocPath(docID)
-			err := removeFile(docPath)
+			docPath, err := c.getDocPath(docID)
+			if err != nil {
+				return fmt.Errorf("couldn't determine document path: %w", err)
+			}
+			err = removeFile(docPath)
 			if err != nil {
 				return fmt.Errorf("couldn't remove document at %q: %w", docPath, err)
 			}
@@ -623,25 +629,25 @@ func (c *Collection) queryEmbedding(ctx context.Context, queryEmbedding, negativ
 	return res, nil
 }
 
-// getDocPath generates the path to the document file.
-func (c *Collection) getDocPath(docID string) string {
-	safeID := hash2hex(docID)
-	docPath := filepath.Join(c.persistDirectory, safeID)
-	docPath += ".gob"
-	if c.compress {
-		docPath += ".gz"
+// getDocPath generates the path to the document file. It returns an error if
+// the collection's compression codec is not registered.
+func (c *Collection) getDocPath(docID string) (string, error) {
+	ext, err := c.compression.fileExtension()
+	if err != nil {
+		return "", err
 	}
-	return docPath
+	safeID := hash2hex(docID)
+	return filepath.Join(c.persistDirectory, safeID) + ext, nil
 }
 
 // persistMetadata persists the collection metadata to disk
 func (c *Collection) persistMetadata() error {
 	// Persist name and metadata
-	metadataPath := filepath.Join(c.persistDirectory, metadataFileName)
-	metadataPath += ".gob"
-	if c.compress {
-		metadataPath += ".gz"
+	ext, err := c.compression.fileExtension()
+	if err != nil {
+		return err
 	}
+	metadataPath := filepath.Join(c.persistDirectory, metadataFileName) + ext
 	pc := struct {
 		Name     string
 		Metadata map[string]string
@@ -649,7 +655,7 @@ func (c *Collection) persistMetadata() error {
 		Name:     c.Name,
 		Metadata: c.metadata,
 	}
-	err := persistToFile(metadataPath, pc, c.compress, "")
+	err = persistToFileWithCompression(metadataPath, pc, c.compression, "")
 	if err != nil {
 		return err
 	}

--- a/collection.go
+++ b/collection.go
@@ -629,8 +629,7 @@ func (c *Collection) queryEmbedding(ctx context.Context, queryEmbedding, negativ
 	return res, nil
 }
 
-// getDocPath generates the path to the document file. It returns an error if
-// the collection's compression codec is not registered.
+// getDocPath generates the path to the document file.
 func (c *Collection) getDocPath(docID string) (string, error) {
 	ext, err := c.compression.fileExtension()
 	if err != nil {

--- a/compression.go
+++ b/compression.go
@@ -1,0 +1,206 @@
+package chromem
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+)
+
+// Compression identifies the compression algorithm used for persistence and
+// export files.
+//
+// The zero value (empty string) has context-dependent meaning:
+//   - Write paths (Export, NewPersistentDB) treat it as [CompressionNone].
+//   - Read paths that accept an optional compression (e.g.
+//     [DB.ImportFromFileWithCompression]) treat it as "auto-detect from magic
+//     bytes". Auto-detect only works for codecs that declare a non-empty
+//     [CompressionCodec.MagicNumber].
+type Compression string
+
+const (
+	// CompressionNone disables compression.
+	CompressionNone Compression = "none"
+
+	// CompressionGzip compresses files with gzip.
+	CompressionGzip Compression = "gzip"
+)
+
+// CompressionCodec describes how to compress and decompress a stream for a
+// given Compression name. External codecs register themselves from client code.
+type CompressionCodec struct {
+	// Extension is appended to ".gob" for on-disk files. It must be empty for
+	// no compression or start with a dot, for example ".zst".
+	Extension string
+
+	// MagicNumber is used to auto-detect the codec on the read path. Codecs with
+	// an empty magic number are not eligible for auto-detection.
+	MagicNumber []byte
+
+	// NewWriter wraps w. The returned WriteCloser must flush all bytes on Close.
+	NewWriter func(w io.Writer) (io.WriteCloser, error)
+
+	// NewReader wraps r. The returned ReadCloser must be safe to Close once.
+	NewReader func(r io.Reader) (io.ReadCloser, error)
+}
+
+var compressionRegistry = struct {
+	sync.RWMutex
+	codecs      map[Compression]CompressionCodec
+	maxMagicLen int
+}{
+	codecs: make(map[Compression]CompressionCodec),
+}
+
+func init() {
+	mustRegisterCompression(CompressionNone, CompressionCodec{
+		NewWriter: func(w io.Writer) (io.WriteCloser, error) {
+			return nopWriteCloser{Writer: w}, nil
+		},
+		NewReader: func(r io.Reader) (io.ReadCloser, error) {
+			return io.NopCloser(r), nil
+		},
+	})
+	mustRegisterCompression(CompressionGzip, CompressionCodec{
+		Extension:   ".gz",
+		MagicNumber: []byte{0x1f, 0x8b},
+		NewWriter: func(w io.Writer) (io.WriteCloser, error) {
+			return gzip.NewWriter(w), nil
+		},
+		NewReader: func(r io.Reader) (io.ReadCloser, error) {
+			return gzip.NewReader(r)
+		},
+	})
+}
+
+// RegisterCompression registers a codec under the given name. The names "none"
+// and "gzip" are reserved for built-in codecs.
+func RegisterCompression(name Compression, codec CompressionCodec) error {
+	if name == "" {
+		return fmt.Errorf("compression name is empty")
+	}
+	if name == CompressionNone || name == CompressionGzip {
+		return fmt.Errorf("compression name %q is reserved", name)
+	}
+	return registerCompression(name, codec)
+}
+
+func mustRegisterCompression(name Compression, codec CompressionCodec) {
+	if err := registerCompression(name, codec); err != nil {
+		panic(err)
+	}
+}
+
+func registerCompression(name Compression, codec CompressionCodec) error {
+	if err := validateCompressionCodec(codec); err != nil {
+		return err
+	}
+
+	codec.MagicNumber = append([]byte(nil), codec.MagicNumber...)
+
+	compressionRegistry.Lock()
+	defer compressionRegistry.Unlock()
+
+	if _, ok := compressionRegistry.codecs[name]; ok {
+		return fmt.Errorf("compression %q is already registered", name)
+	}
+	for registeredName, registeredCodec := range compressionRegistry.codecs {
+		if codec.Extension == registeredCodec.Extension {
+			return fmt.Errorf("compression extension %q is already registered for %q", codec.Extension, registeredName)
+		}
+		if magicNumbersOverlap(codec.MagicNumber, registeredCodec.MagicNumber) {
+			return fmt.Errorf("compression magic number for %q overlaps with %q", name, registeredName)
+		}
+	}
+
+	compressionRegistry.codecs[name] = codec
+	if len(codec.MagicNumber) > compressionRegistry.maxMagicLen {
+		compressionRegistry.maxMagicLen = len(codec.MagicNumber)
+	}
+	return nil
+}
+
+func validateCompressionCodec(codec CompressionCodec) error {
+	if codec.Extension != "" && !strings.HasPrefix(codec.Extension, ".") {
+		return fmt.Errorf("compression extension %q must start with a dot", codec.Extension)
+	}
+	if codec.NewWriter == nil {
+		return fmt.Errorf("compression writer constructor is nil")
+	}
+	if codec.NewReader == nil {
+		return fmt.Errorf("compression reader constructor is nil")
+	}
+	return nil
+}
+
+func magicNumbersOverlap(a, b []byte) bool {
+	if len(a) == 0 || len(b) == 0 {
+		return false
+	}
+	if len(a) <= len(b) {
+		return string(a) == string(b[:len(a)])
+	}
+	return string(b) == string(a[:len(b)])
+}
+
+func lookupCompressionCodec(compression Compression) (CompressionCodec, bool) {
+	if compression == "" {
+		compression = CompressionNone
+	}
+	compressionRegistry.RLock()
+	defer compressionRegistry.RUnlock()
+	codec, ok := compressionRegistry.codecs[compression]
+	return codec, ok
+}
+
+func detectCompressionCodec(prefix []byte) (CompressionCodec, Compression, bool) {
+	compressionRegistry.RLock()
+	defer compressionRegistry.RUnlock()
+	for name, codec := range compressionRegistry.codecs {
+		if len(codec.MagicNumber) == 0 || len(prefix) < len(codec.MagicNumber) {
+			continue
+		}
+		if string(prefix[:len(codec.MagicNumber)]) == string(codec.MagicNumber) {
+			return codec, name, true
+		}
+	}
+	codec, ok := compressionRegistry.codecs[CompressionNone]
+	return codec, CompressionNone, ok
+}
+
+func maxCompressionMagicLen() int {
+	compressionRegistry.RLock()
+	defer compressionRegistry.RUnlock()
+	return compressionRegistry.maxMagicLen
+}
+
+func compressionFromBool(compress bool) Compression {
+	if compress {
+		return CompressionGzip
+	}
+	return CompressionNone
+}
+
+func (c Compression) validate() error {
+	if _, ok := lookupCompressionCodec(c); !ok {
+		return fmt.Errorf("unsupported compression: %q", c)
+	}
+	return nil
+}
+
+func (c Compression) fileExtension() (string, error) {
+	codec, ok := lookupCompressionCodec(c)
+	if !ok {
+		return "", fmt.Errorf("unsupported compression: %q", c)
+	}
+	return ".gob" + codec.Extension, nil
+}
+
+type nopWriteCloser struct {
+	io.Writer
+}
+
+func (n nopWriteCloser) Close() error {
+	return nil
+}

--- a/compression.go
+++ b/compression.go
@@ -8,15 +8,7 @@ import (
 	"sync"
 )
 
-// Compression identifies the compression algorithm used for persistence and
-// export files.
-//
-// The zero value (empty string) has context-dependent meaning:
-//   - Write paths (Export, NewPersistentDB) treat it as [CompressionNone].
-//   - Read paths that accept an optional compression (e.g.
-//     [DB.ImportFromFileWithCompression]) treat it as "auto-detect from magic
-//     bytes". Auto-detect only works for codecs that declare a non-empty
-//     [CompressionCodec.MagicNumber].
+// Compression identifies a registered persistence and export codec.
 type Compression string
 
 const (
@@ -27,21 +19,18 @@ const (
 	CompressionGzip Compression = "gzip"
 )
 
-// CompressionCodec describes how to compress and decompress a stream for a
-// given Compression name. External codecs register themselves from client code.
+// CompressionCodec describes a compression implementation.
 type CompressionCodec struct {
-	// Extension is appended to ".gob" for on-disk files. It must be empty for
-	// no compression or start with a dot, for example ".zst".
+	// Extension is appended to ".gob" for on-disk files.
 	Extension string
 
-	// MagicNumber is used to auto-detect the codec on the read path. Codecs with
-	// an empty magic number are not eligible for auto-detection.
+	// MagicNumber enables auto-detection on read.
 	MagicNumber []byte
 
-	// NewWriter wraps w. The returned WriteCloser must flush all bytes on Close.
+	// NewWriter wraps w with a compression writer.
 	NewWriter func(w io.Writer) (io.WriteCloser, error)
 
-	// NewReader wraps r. The returned ReadCloser must be safe to Close once.
+	// NewReader wraps r with a compression reader.
 	NewReader func(r io.Reader) (io.ReadCloser, error)
 }
 
@@ -74,8 +63,7 @@ func init() {
 	})
 }
 
-// RegisterCompression registers a codec under the given name. The names "none"
-// and "gzip" are reserved for built-in codecs.
+// RegisterCompression registers a codec under the given name.
 func RegisterCompression(name Compression, codec CompressionCodec) error {
 	if name == "" {
 		return fmt.Errorf("compression name is empty")

--- a/compression_test.go
+++ b/compression_test.go
@@ -1,0 +1,255 @@
+package chromem
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestRegisterCompression(t *testing.T) {
+	codec := testCompressionCodec(".tc1", []byte("tc1"))
+	if err := RegisterCompression("test-register", codec); err != nil {
+		t.Fatal("expected nil, got", err)
+	}
+	if err := RegisterCompression("test-register", testCompressionCodec(".tc2", []byte("tc2"))); err == nil {
+		t.Fatal("expected duplicate name error, got nil")
+	}
+	if err := RegisterCompression(CompressionGzip, testCompressionCodec(".tc3", []byte("tc3"))); err == nil {
+		t.Fatal("expected reserved name error, got nil")
+	}
+	if err := RegisterCompression("test-bad-extension", CompressionCodec{
+		Extension:   "bad",
+		MagicNumber: []byte("tc4"),
+		NewWriter:   codec.NewWriter,
+		NewReader:   codec.NewReader,
+	}); err == nil {
+		t.Fatal("expected invalid extension error, got nil")
+	}
+	if err := RegisterCompression("test-duplicate-extension", CompressionCodec{
+		Extension:   ".tc1",
+		MagicNumber: []byte("tc5"),
+		NewWriter:   codec.NewWriter,
+		NewReader:   codec.NewReader,
+	}); err == nil {
+		t.Fatal("expected duplicate extension error, got nil")
+	}
+	if err := RegisterCompression("test-overlapping-magic", CompressionCodec{
+		Extension:   ".test-overlapping-magic",
+		MagicNumber: []byte("tc1-overlap"),
+		NewWriter:   codec.NewWriter,
+		NewReader:   codec.NewReader,
+	}); err == nil {
+		t.Fatal("expected overlapping magic error, got nil")
+	}
+}
+
+func TestCompressionCodecRoundTrip(t *testing.T) {
+	compression := Compression("test-roundtrip")
+	if err := RegisterCompression(compression, testCompressionCodec(".roundtrip", []byte("tr1"))); err != nil {
+		t.Fatal("expected nil, got", err)
+	}
+
+	type s struct {
+		Foo string
+		Bar []float32
+	}
+	obj := s{
+		Foo: "test",
+		Bar: []float32{-0.40824828, 0.40824828, 0.81649655},
+	}
+
+	filePath := filepath.Join(t.TempDir(), "test.gob.roundtrip")
+	if err := persistToFileWithCompression(filePath, obj, compression, ""); err != nil {
+		t.Fatal("expected nil, got", err)
+	}
+	var got s
+	if err := readFromFile(filePath, &got, ""); err != nil {
+		t.Fatal("expected nil, got", err)
+	}
+	if !reflect.DeepEqual(obj, got) {
+		t.Fatalf("expected %+v, got %+v", obj, got)
+	}
+}
+
+func TestDBExportWithRegisteredCompression(t *testing.T) {
+	compression := Compression("test-db-export")
+	if err := RegisterCompression(compression, testCompressionCodec(".db-export", []byte("tdb"))); err != nil {
+		t.Fatal("expected nil, got", err)
+	}
+
+	vectors := []float32{-0.40824828, 0.40824828, 0.81649655}
+	embeddingFunc := func(_ context.Context, _ string) ([]float32, error) {
+		return vectors, nil
+	}
+
+	origDB := NewDB()
+	c, err := origDB.CreateCollection("test", map[string]string{"foo": "bar"}, embeddingFunc)
+	if err != nil {
+		t.Fatal("expected nil, got", err)
+	}
+	if err := c.AddDocument(context.Background(), Document{
+		ID:        "doc1",
+		Metadata:  map[string]string{"foo": "bar"},
+		Embedding: vectors,
+		Content:   "test",
+	}); err != nil {
+		t.Fatal("expected nil, got", err)
+	}
+
+	var buf bytes.Buffer
+	if err := origDB.ExportToWriterWithCompression(&buf, compression, ""); err != nil {
+		t.Fatal("expected nil, got", err)
+	}
+
+	newDB := NewDB()
+	if err := newDB.ImportFromReader(bytes.NewReader(buf.Bytes()), ""); err != nil {
+		t.Fatal("expected nil, got", err)
+	}
+
+	c.embed = nil
+	if !reflect.DeepEqual(origDB, newDB) {
+		t.Fatalf("expected DB %+v, got %+v", origDB, newDB)
+	}
+}
+
+func TestDBImportFromReaderWithCompression(t *testing.T) {
+	compression := Compression("test-import-explicit")
+	if err := RegisterCompression(compression, testCompressionCodec(".import-explicit", []byte("imp"))); err != nil {
+		t.Fatal("expected nil, got", err)
+	}
+
+	vectors := []float32{-0.40824828, 0.40824828, 0.81649655}
+	embeddingFunc := func(_ context.Context, _ string) ([]float32, error) {
+		return vectors, nil
+	}
+
+	origDB := NewDB()
+	c, err := origDB.CreateCollection("test", map[string]string{"foo": "bar"}, embeddingFunc)
+	if err != nil {
+		t.Fatal("expected nil, got", err)
+	}
+	if err := c.AddDocument(context.Background(), Document{
+		ID:        "doc1",
+		Metadata:  map[string]string{"foo": "bar"},
+		Embedding: vectors,
+		Content:   "test",
+	}); err != nil {
+		t.Fatal("expected nil, got", err)
+	}
+
+	var buf bytes.Buffer
+	if err := origDB.ExportToWriterWithCompression(&buf, compression, ""); err != nil {
+		t.Fatal("expected nil, got", err)
+	}
+
+	newDB := NewDB()
+	if err := newDB.ImportFromReaderWithCompression(bytes.NewReader(buf.Bytes()), compression, ""); err != nil {
+		t.Fatal("expected nil, got", err)
+	}
+	c.embed = nil
+	if !reflect.DeepEqual(origDB, newDB) {
+		t.Fatalf("expected DB %+v, got %+v", origDB, newDB)
+	}
+
+	// Unknown compression name should error.
+	if err := NewDB().ImportFromReaderWithCompression(bytes.NewReader(buf.Bytes()), "no-such-codec", ""); err == nil {
+		t.Fatal("expected error for unknown compression, got nil")
+	}
+}
+
+func TestPersistentDBWithRegisteredCompression(t *testing.T) {
+	compression := Compression("test-persistent")
+	if err := RegisterCompression(compression, testCompressionCodec(".test-persistent", nil)); err != nil {
+		t.Fatal("expected nil, got", err)
+	}
+
+	vectors := []float32{-0.40824828, 0.40824828, 0.81649655}
+	embeddingFunc := func(_ context.Context, _ string) ([]float32, error) {
+		return vectors, nil
+	}
+
+	dir := t.TempDir()
+	db, err := NewPersistentDBWithCompression(dir, compression)
+	if err != nil {
+		t.Fatal("expected nil, got", err)
+	}
+	c, err := db.CreateCollection("test", map[string]string{"foo": "bar"}, embeddingFunc)
+	if err != nil {
+		t.Fatal("expected nil, got", err)
+	}
+	doc := Document{
+		ID:        "doc1",
+		Metadata:  map[string]string{"foo": "bar"},
+		Embedding: vectors,
+		Content:   "test",
+	}
+	if err := c.AddDocument(context.Background(), doc); err != nil {
+		t.Fatal("expected nil, got", err)
+	}
+	if _, err := os.Stat(filepath.Join(c.persistDirectory, metadataFileName+".gob.test-persistent")); err != nil {
+		t.Fatal("expected metadata file to exist, got", err)
+	}
+
+	loadedDB, err := NewPersistentDBWithCompression(dir, compression)
+	if err != nil {
+		t.Fatal("expected nil, got", err)
+	}
+	loadedCollection := loadedDB.GetCollection("test", embeddingFunc)
+	if loadedCollection == nil {
+		t.Fatal("expected collection, got nil")
+	}
+	got, err := loadedCollection.GetByID(context.Background(), doc.ID)
+	if err != nil {
+		t.Fatal("expected nil, got", err)
+	}
+	if !reflect.DeepEqual(doc, got) {
+		t.Fatalf("expected %+v, got %+v", doc, got)
+	}
+}
+
+func testCompressionCodec(extension string, magic []byte) CompressionCodec {
+	return CompressionCodec{
+		Extension:   extension,
+		MagicNumber: magic,
+		NewWriter: func(w io.Writer) (io.WriteCloser, error) {
+			return &testCompressionWriter{w: w, magic: magic}, nil
+		},
+		NewReader: func(r io.Reader) (io.ReadCloser, error) {
+			if len(magic) > 0 {
+				got := make([]byte, len(magic))
+				if _, err := io.ReadFull(r, got); err != nil {
+					return nil, err
+				}
+				if !bytes.Equal(got, magic) {
+					return nil, fmt.Errorf("unexpected magic number %q", got)
+				}
+			}
+			return io.NopCloser(r), nil
+		},
+	}
+}
+
+type testCompressionWriter struct {
+	w     io.Writer
+	magic []byte
+	wrote bool
+}
+
+func (w *testCompressionWriter) Write(p []byte) (int, error) {
+	if !w.wrote {
+		w.wrote = true
+		if _, err := w.w.Write(w.magic); err != nil {
+			return 0, err
+		}
+	}
+	return w.w.Write(p)
+}
+
+func (w *testCompressionWriter) Close() error {
+	return nil
+}

--- a/db.go
+++ b/db.go
@@ -31,7 +31,7 @@ type DB struct {
 	collectionsLock sync.RWMutex
 
 	persistDirectory string
-	compress         bool
+	compression      Compression
 
 	// ⚠️ When adding fields here, consider adding them to the persistence struct
 	// versions in [DB.Export] and [DB.Import] as well!
@@ -66,6 +66,32 @@ func NewDB() *DB {
 // [DB.ImportFromReader] to export and import the entire DB to/from a file or
 // writer/reader, which also works for the pure in-memory DB.
 func NewPersistentDB(path string, compress bool) (*DB, error) {
+	return NewPersistentDBWithCompression(path, compressionFromBool(compress))
+}
+
+// NewPersistentDBWithCompression creates a new persistent chromem-go DB.
+// If the path is empty, it defaults to "./chromem-go".
+// If compression is provided, the files are compressed with that registered
+// algorithm.
+//
+// The persistence covers the collections (including their documents) and the metadata.
+// However, it doesn't cover the EmbeddingFunc, as functions can't be serialized.
+// When some data is persisted, and you create a new persistent DB with the same
+// path, you'll have to provide the same EmbeddingFunc as before when getting an
+// existing collection and adding more documents to it.
+//
+// Currently, the persistence is done synchronously on each write operation, and
+// each document addition leads to a new file, encoded as gob. In the future we
+// will make this configurable (encoding, async writes, WAL-based writes, etc.).
+//
+// In addition to persistence for each added collection and document you can use
+// [DB.ExportToFile] / [DB.ExportToWriter] and [DB.ImportFromFile] /
+// [DB.ImportFromReader] to export and import the entire DB to/from a file or
+// writer/reader, which also works for the pure in-memory DB.
+func NewPersistentDBWithCompression(path string, compression Compression) (*DB, error) {
+	if err := compression.validate(); err != nil {
+		return nil, err
+	}
 	if path == "" {
 		path = "./chromem-go"
 	} else {
@@ -74,15 +100,15 @@ func NewPersistentDB(path string, compress bool) (*DB, error) {
 	}
 
 	// We check for this file extension and skip others
-	ext := ".gob"
-	if compress {
-		ext += ".gz"
+	ext, err := compression.fileExtension()
+	if err != nil {
+		return nil, err
 	}
 
 	db := &DB{
 		collections:      make(map[string]*Collection),
 		persistDirectory: path,
-		compress:         compress,
+		compression:      compression,
 	}
 
 	// If the directory doesn't exist, create it and return an empty DB.
@@ -124,7 +150,7 @@ func NewPersistentDB(path string, compress bool) (*DB, error) {
 		c := &Collection{
 			documents:        make(map[string]*Document),
 			persistDirectory: collectionPath,
-			compress:         compress,
+			compression:      compression,
 			// We can fill Name and metadata only after reading
 			// the metadata.
 			// We can fill embed only when the user calls DB.GetCollection() or
@@ -145,7 +171,7 @@ func NewPersistentDB(path string, compress bool) (*DB, error) {
 					Name     string
 					Metadata map[string]string
 				}{}
-				err := readFromFile(fPath, &pc, "")
+				err := readFromFileWithCompression(fPath, &pc, "", compression)
 				if err != nil {
 					return nil, fmt.Errorf("couldn't read collection metadata: %w", err)
 				}
@@ -154,7 +180,7 @@ func NewPersistentDB(path string, compress bool) (*DB, error) {
 			} else if strings.HasSuffix(collectionDirEntry.Name(), ext) {
 				// Read document
 				d := &Document{}
-				err := readFromFile(fPath, d, "")
+				err := readFromFileWithCompression(fPath, d, "", compression)
 				if err != nil {
 					return nil, fmt.Errorf("couldn't read document: %w", err)
 				}
@@ -181,8 +207,8 @@ func NewPersistentDB(path string, compress bool) (*DB, error) {
 }
 
 // Import imports the DB from a file at the given path. The file must be encoded
-// as gob and can optionally be compressed with flate (as gzip) and encrypted
-// with AES-GCM.
+// as gob and can optionally be compressed with gzip or another registered codec
+// and encrypted with AES-GCM.
 // This works for both the in-memory and persistent DBs.
 // Existing collections are overwritten.
 //
@@ -195,8 +221,10 @@ func (db *DB) Import(filePath string, encryptionKey string) error {
 }
 
 // ImportFromFile imports the DB from a file at the given path. The file must be
-// encoded as gob and can optionally be compressed with flate (as gzip) and encrypted
-// with AES-GCM.
+// encoded as gob and can optionally be compressed with gzip or another
+// registered codec (with a non-empty magic number) and encrypted with AES-GCM.
+// The codec is auto-detected by magic bytes; for codecs without a magic number,
+// use [DB.ImportFromFileWithCompression] to specify the codec explicitly.
 // This works for both the in-memory and persistent DBs.
 // Existing collections are overwritten.
 //
@@ -206,8 +234,31 @@ func (db *DB) Import(filePath string, encryptionKey string) error {
 //     are imported. Non-existing collections are ignored.
 //     If not provided, all collections are imported.
 func (db *DB) ImportFromFile(filePath string, encryptionKey string, collections ...string) error {
+	return db.ImportFromFileWithCompression(filePath, "", encryptionKey, collections...)
+}
+
+// ImportFromFileWithCompression imports the DB from a file at the given path.
+// The file must be encoded as gob and can optionally be compressed and
+// encrypted with AES-GCM.
+// This works for both the in-memory and persistent DBs.
+// Existing collections are overwritten.
+//
+//   - filePath: Mandatory, must not be empty
+//   - compression: Optional. If empty, the codec is auto-detected from magic
+//     bytes (only works for codecs that declare a non-empty MagicNumber).
+//     If non-empty, the named codec must be registered.
+//   - encryptionKey: Optional, must be 32 bytes long if provided
+//   - collections: Optional. If provided, only the collections with the given names
+//     are imported. Non-existing collections are ignored.
+//     If not provided, all collections are imported.
+func (db *DB) ImportFromFileWithCompression(filePath string, compression Compression, encryptionKey string, collections ...string) error {
 	if filePath == "" {
 		return fmt.Errorf("file path is empty")
+	}
+	if compression != "" {
+		if err := compression.validate(); err != nil {
+			return err
+		}
 	}
 	if encryptionKey != "" {
 		// AES 256 requires a 32 byte key
@@ -243,7 +294,7 @@ func (db *DB) ImportFromFile(filePath string, encryptionKey string, collections 
 	db.collectionsLock.Lock()
 	defer db.collectionsLock.Unlock()
 
-	err = readFromFile(filePath, &persistenceDB, encryptionKey)
+	err = readFromFileWithCompression(filePath, &persistenceDB, encryptionKey, compression)
 	if err != nil {
 		return fmt.Errorf("couldn't read file: %w", err)
 	}
@@ -260,14 +311,17 @@ func (db *DB) ImportFromFile(filePath string, encryptionKey string, collections 
 		}
 		if db.persistDirectory != "" {
 			c.persistDirectory = filepath.Join(db.persistDirectory, hash2hex(pc.Name))
-			c.compress = db.compress
+			c.compression = db.compression
 			err = c.persistMetadata()
 			if err != nil {
 				return fmt.Errorf("couldn't persist collection metadata: %w", err)
 			}
 			for _, doc := range c.documents {
-				docPath := c.getDocPath(doc.ID)
-				err = persistToFile(docPath, doc, c.compress, "")
+				docPath, err := c.getDocPath(doc.ID)
+				if err != nil {
+					return fmt.Errorf("couldn't determine document path: %w", err)
+				}
+				err = persistToFileWithCompression(docPath, doc, c.compression, "")
 				if err != nil {
 					return fmt.Errorf("couldn't persist document to %q: %w", docPath, err)
 				}
@@ -280,8 +334,10 @@ func (db *DB) ImportFromFile(filePath string, encryptionKey string, collections 
 }
 
 // ImportFromReader imports the DB from a reader. The stream must be encoded as
-// gob and can optionally be compressed with flate (as gzip) and encrypted with
-// AES-GCM.
+// gob and can optionally be compressed with gzip or another registered codec
+// (with a non-empty magic number) and encrypted with AES-GCM.
+// The codec is auto-detected by magic bytes; for codecs without a magic number,
+// use [DB.ImportFromReaderWithCompression] to specify the codec explicitly.
 // This works for both the in-memory and persistent DBs.
 // Existing collections are overwritten.
 // If the writer has to be closed, it's the caller's responsibility.
@@ -295,6 +351,29 @@ func (db *DB) ImportFromFile(filePath string, encryptionKey string, collections 
 //     are imported. Non-existing collections are ignored.
 //     If not provided, all collections are imported.
 func (db *DB) ImportFromReader(reader io.ReadSeeker, encryptionKey string, collections ...string) error {
+	return db.ImportFromReaderWithCompression(reader, "", encryptionKey, collections...)
+}
+
+// ImportFromReaderWithCompression imports the DB from a reader. The stream must
+// be encoded as gob and can optionally be compressed and encrypted with AES-GCM.
+// This works for both the in-memory and persistent DBs.
+// Existing collections are overwritten.
+// If the reader has to be closed, it's the caller's responsibility.
+//
+//   - reader: An implementation of [io.ReadSeeker]
+//   - compression: Optional. If empty, the codec is auto-detected from magic
+//     bytes (only works for codecs that declare a non-empty MagicNumber).
+//     If non-empty, the named codec must be registered.
+//   - encryptionKey: Optional, must be 32 bytes long if provided
+//   - collections: Optional. If provided, only the collections with the given names
+//     are imported. Non-existing collections are ignored.
+//     If not provided, all collections are imported.
+func (db *DB) ImportFromReaderWithCompression(reader io.ReadSeeker, compression Compression, encryptionKey string, collections ...string) error {
+	if compression != "" {
+		if err := compression.validate(); err != nil {
+			return err
+		}
+	}
 	if encryptionKey != "" {
 		// AES 256 requires a 32 byte key
 		if len(encryptionKey) != 32 {
@@ -318,7 +397,7 @@ func (db *DB) ImportFromReader(reader io.ReadSeeker, encryptionKey string, colle
 	db.collectionsLock.Lock()
 	defer db.collectionsLock.Unlock()
 
-	err := readFromReader(reader, &persistenceDB, encryptionKey)
+	err := readFromReaderWithCompression(reader, &persistenceDB, encryptionKey, compression)
 	if err != nil {
 		return fmt.Errorf("couldn't read stream: %w", err)
 	}
@@ -335,14 +414,17 @@ func (db *DB) ImportFromReader(reader io.ReadSeeker, encryptionKey string, colle
 		}
 		if db.persistDirectory != "" {
 			c.persistDirectory = filepath.Join(db.persistDirectory, hash2hex(pc.Name))
-			c.compress = db.compress
+			c.compression = db.compression
 			err = c.persistMetadata()
 			if err != nil {
 				return fmt.Errorf("couldn't persist collection metadata: %w", err)
 			}
 			for _, doc := range c.documents {
-				docPath := c.getDocPath(doc.ID)
-				err := persistToFile(docPath, doc, c.compress, "")
+				docPath, err := c.getDocPath(doc.ID)
+				if err != nil {
+					return fmt.Errorf("couldn't determine document path: %w", err)
+				}
+				err = persistToFileWithCompression(docPath, doc, c.compression, "")
 				if err != nil {
 					return fmt.Errorf("couldn't persist document to %q: %w", docPath, err)
 				}
@@ -382,11 +464,32 @@ func (db *DB) Export(filePath string, compress bool, encryptionKey string) error
 //     are exported. Non-existing collections are ignored.
 //     If not provided, all collections are exported.
 func (db *DB) ExportToFile(filePath string, compress bool, encryptionKey string, collections ...string) error {
+	return db.ExportToFileWithCompression(filePath, compressionFromBool(compress), encryptionKey, collections...)
+}
+
+// ExportToFileWithCompression exports the DB to a file at the given path. The file is
+// encoded as gob, optionally compressed with a registered codec and optionally
+// encrypted with AES-GCM.
+// This works for both the in-memory and persistent DBs.
+// If the file exists, it's overwritten, otherwise created.
+//
+//   - filePath: If empty, it defaults to "./chromem-go.gob" (+ compression extension + ".enc")
+//   - compression: Optional. Compresses with the given registered algorithm.
+//   - encryptionKey: Optional. Encrypts with AES-GCM if provided. Must be 32 bytes
+//     long if provided.
+//   - collections: Optional. If provided, only the collections with the given names
+//     are exported. Non-existing collections are ignored.
+//     If not provided, all collections are exported.
+func (db *DB) ExportToFileWithCompression(filePath string, compression Compression, encryptionKey string, collections ...string) error {
+	if err := compression.validate(); err != nil {
+		return err
+	}
 	if filePath == "" {
-		filePath = "./chromem-go.gob"
-		if compress {
-			filePath += ".gz"
+		ext, err := compression.fileExtension()
+		if err != nil {
+			return err
 		}
+		filePath = "./chromem-go" + ext
 		if encryptionKey != "" {
 			filePath += ".enc"
 		}
@@ -424,7 +527,7 @@ func (db *DB) ExportToFile(filePath string, compress bool, encryptionKey string,
 		}
 	}
 
-	err := persistToFile(filePath, persistenceDB, compress, encryptionKey)
+	err := persistToFileWithCompression(filePath, persistenceDB, compression, encryptionKey)
 	if err != nil {
 		return fmt.Errorf("couldn't export DB: %w", err)
 	}
@@ -448,6 +551,29 @@ func (db *DB) ExportToFile(filePath string, compress bool, encryptionKey string,
 //     are exported. Non-existing collections are ignored.
 //     If not provided, all collections are exported.
 func (db *DB) ExportToWriter(writer io.Writer, compress bool, encryptionKey string, collections ...string) error {
+	return db.ExportToWriterWithCompression(writer, compressionFromBool(compress), encryptionKey, collections...)
+}
+
+// ExportToWriterWithCompression exports the DB to a writer. The stream is encoded as
+// gob, optionally compressed with a registered codec and optionally encrypted
+// with AES-GCM.
+// This works for both the in-memory and persistent DBs.
+// If the writer has to be closed, it's the caller's responsibility.
+// This can be used to export DBs to object storage like S3. See
+// https://github.com/philippgille/chromem-go/tree/main/examples/s3-export-import
+// for an example.
+//
+//   - writer: An implementation of [io.Writer]
+//   - compression: Optional. Compresses with the given registered algorithm.
+//   - encryptionKey: Optional. Encrypts with AES-GCM if provided. Must be 32 bytes
+//     long if provided.
+//   - collections: Optional. If provided, only the collections with the given names
+//     are exported. Non-existing collections are ignored.
+//     If not provided, all collections are exported.
+func (db *DB) ExportToWriterWithCompression(writer io.Writer, compression Compression, encryptionKey string, collections ...string) error {
+	if err := compression.validate(); err != nil {
+		return err
+	}
 	if encryptionKey != "" {
 		// AES 256 requires a 32 byte key
 		if len(encryptionKey) != 32 {
@@ -481,7 +607,7 @@ func (db *DB) ExportToWriter(writer io.Writer, compress bool, encryptionKey stri
 		}
 	}
 
-	err := persistToWriter(writer, persistenceDB, compress, encryptionKey)
+	err := persistToWriterWithCompression(writer, persistenceDB, compression, encryptionKey)
 	if err != nil {
 		return fmt.Errorf("couldn't export DB: %w", err)
 	}
@@ -502,7 +628,7 @@ func (db *DB) CreateCollection(name string, metadata map[string]string, embeddin
 	if embeddingFunc == nil {
 		embeddingFunc = NewEmbeddingFuncDefault()
 	}
-	collection, err := newCollection(name, metadata, embeddingFunc, db.persistDirectory, db.compress)
+	collection, err := newCollection(name, metadata, embeddingFunc, db.persistDirectory, db.compression)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create collection: %w", err)
 	}

--- a/db.go
+++ b/db.go
@@ -69,25 +69,8 @@ func NewPersistentDB(path string, compress bool) (*DB, error) {
 	return NewPersistentDBWithCompression(path, compressionFromBool(compress))
 }
 
-// NewPersistentDBWithCompression creates a new persistent chromem-go DB.
-// If the path is empty, it defaults to "./chromem-go".
-// If compression is provided, the files are compressed with that registered
-// algorithm.
-//
-// The persistence covers the collections (including their documents) and the metadata.
-// However, it doesn't cover the EmbeddingFunc, as functions can't be serialized.
-// When some data is persisted, and you create a new persistent DB with the same
-// path, you'll have to provide the same EmbeddingFunc as before when getting an
-// existing collection and adding more documents to it.
-//
-// Currently, the persistence is done synchronously on each write operation, and
-// each document addition leads to a new file, encoded as gob. In the future we
-// will make this configurable (encoding, async writes, WAL-based writes, etc.).
-//
-// In addition to persistence for each added collection and document you can use
-// [DB.ExportToFile] / [DB.ExportToWriter] and [DB.ImportFromFile] /
-// [DB.ImportFromReader] to export and import the entire DB to/from a file or
-// writer/reader, which also works for the pure in-memory DB.
+// NewPersistentDBWithCompression is like [NewPersistentDB], but uses a
+// registered compression codec.
 func NewPersistentDBWithCompression(path string, compression Compression) (*DB, error) {
 	if err := compression.validate(); err != nil {
 		return nil, err
@@ -222,9 +205,7 @@ func (db *DB) Import(filePath string, encryptionKey string) error {
 
 // ImportFromFile imports the DB from a file at the given path. The file must be
 // encoded as gob and can optionally be compressed with gzip or another
-// registered codec (with a non-empty magic number) and encrypted with AES-GCM.
-// The codec is auto-detected by magic bytes; for codecs without a magic number,
-// use [DB.ImportFromFileWithCompression] to specify the codec explicitly.
+// registered codec with a magic number, and encrypted with AES-GCM.
 // This works for both the in-memory and persistent DBs.
 // Existing collections are overwritten.
 //
@@ -237,16 +218,11 @@ func (db *DB) ImportFromFile(filePath string, encryptionKey string, collections 
 	return db.ImportFromFileWithCompression(filePath, "", encryptionKey, collections...)
 }
 
-// ImportFromFileWithCompression imports the DB from a file at the given path.
-// The file must be encoded as gob and can optionally be compressed and
-// encrypted with AES-GCM.
-// This works for both the in-memory and persistent DBs.
-// Existing collections are overwritten.
+// ImportFromFileWithCompression is like [DB.ImportFromFile], but can use a
+// specific registered compression codec.
 //
 //   - filePath: Mandatory, must not be empty
-//   - compression: Optional. If empty, the codec is auto-detected from magic
-//     bytes (only works for codecs that declare a non-empty MagicNumber).
-//     If non-empty, the named codec must be registered.
+//   - compression: Optional. If empty, the codec is auto-detected from magic bytes.
 //   - encryptionKey: Optional, must be 32 bytes long if provided
 //   - collections: Optional. If provided, only the collections with the given names
 //     are imported. Non-existing collections are ignored.
@@ -335,9 +311,7 @@ func (db *DB) ImportFromFileWithCompression(filePath string, compression Compres
 
 // ImportFromReader imports the DB from a reader. The stream must be encoded as
 // gob and can optionally be compressed with gzip or another registered codec
-// (with a non-empty magic number) and encrypted with AES-GCM.
-// The codec is auto-detected by magic bytes; for codecs without a magic number,
-// use [DB.ImportFromReaderWithCompression] to specify the codec explicitly.
+// with a magic number, and encrypted with AES-GCM.
 // This works for both the in-memory and persistent DBs.
 // Existing collections are overwritten.
 // If the writer has to be closed, it's the caller's responsibility.
@@ -354,16 +328,11 @@ func (db *DB) ImportFromReader(reader io.ReadSeeker, encryptionKey string, colle
 	return db.ImportFromReaderWithCompression(reader, "", encryptionKey, collections...)
 }
 
-// ImportFromReaderWithCompression imports the DB from a reader. The stream must
-// be encoded as gob and can optionally be compressed and encrypted with AES-GCM.
-// This works for both the in-memory and persistent DBs.
-// Existing collections are overwritten.
-// If the reader has to be closed, it's the caller's responsibility.
+// ImportFromReaderWithCompression is like [DB.ImportFromReader], but can use a
+// specific registered compression codec.
 //
 //   - reader: An implementation of [io.ReadSeeker]
-//   - compression: Optional. If empty, the codec is auto-detected from magic
-//     bytes (only works for codecs that declare a non-empty MagicNumber).
-//     If non-empty, the named codec must be registered.
+//   - compression: Optional. If empty, the codec is auto-detected from magic bytes.
 //   - encryptionKey: Optional, must be 32 bytes long if provided
 //   - collections: Optional. If provided, only the collections with the given names
 //     are imported. Non-existing collections are ignored.
@@ -467,14 +436,11 @@ func (db *DB) ExportToFile(filePath string, compress bool, encryptionKey string,
 	return db.ExportToFileWithCompression(filePath, compressionFromBool(compress), encryptionKey, collections...)
 }
 
-// ExportToFileWithCompression exports the DB to a file at the given path. The file is
-// encoded as gob, optionally compressed with a registered codec and optionally
-// encrypted with AES-GCM.
-// This works for both the in-memory and persistent DBs.
-// If the file exists, it's overwritten, otherwise created.
+// ExportToFileWithCompression is like [DB.ExportToFile], but uses a registered
+// compression codec.
 //
 //   - filePath: If empty, it defaults to "./chromem-go.gob" (+ compression extension + ".enc")
-//   - compression: Optional. Compresses with the given registered algorithm.
+//   - compression: Optional. Compresses with the given codec.
 //   - encryptionKey: Optional. Encrypts with AES-GCM if provided. Must be 32 bytes
 //     long if provided.
 //   - collections: Optional. If provided, only the collections with the given names
@@ -554,17 +520,11 @@ func (db *DB) ExportToWriter(writer io.Writer, compress bool, encryptionKey stri
 	return db.ExportToWriterWithCompression(writer, compressionFromBool(compress), encryptionKey, collections...)
 }
 
-// ExportToWriterWithCompression exports the DB to a writer. The stream is encoded as
-// gob, optionally compressed with a registered codec and optionally encrypted
-// with AES-GCM.
-// This works for both the in-memory and persistent DBs.
-// If the writer has to be closed, it's the caller's responsibility.
-// This can be used to export DBs to object storage like S3. See
-// https://github.com/philippgille/chromem-go/tree/main/examples/s3-export-import
-// for an example.
+// ExportToWriterWithCompression is like [DB.ExportToWriter], but uses a
+// registered compression codec.
 //
 //   - writer: An implementation of [io.Writer]
-//   - compression: Optional. Compresses with the given registered algorithm.
+//   - compression: Optional. Compresses with the given codec.
 //   - encryptionKey: Optional. Encrypts with AES-GCM if provided. Must be 32 bytes
 //     long if provided.
 //   - collections: Optional. If provided, only the collections with the given names

--- a/db_test.go
+++ b/db_test.go
@@ -245,7 +245,11 @@ func TestDB_ImportExportSpecificCollections(t *testing.T) {
 	// Make sure that the imported documents are actually persisted on disk
 	for _, col := range newPDB.collections {
 		for _, d := range col.documents {
-			_, err = os.Stat(col.getDocPath(d.ID))
+			docPath, err := col.getDocPath(d.ID)
+			if err != nil {
+				t.Fatalf("expected no error from getDocPath for doc %q, got %v", d.ID, err)
+			}
+			_, err = os.Stat(docPath)
 			if err != nil {
 				t.Fatalf("expected no error when looking up persistent file for doc %q, got %v", d.ID, err)
 			}
@@ -271,7 +275,11 @@ func TestDB_ImportExportSpecificCollections(t *testing.T) {
 	// Make sure that the imported documents are actually persisted on disk
 	for _, col := range newPDB.collections {
 		for _, d := range col.documents {
-			_, err = os.Stat(col.getDocPath(d.ID))
+			docPath, err := col.getDocPath(d.ID)
+			if err != nil {
+				t.Fatalf("expected no error from getDocPath for doc %q, got %v", d.ID, err)
+			}
+			_, err = os.Stat(docPath)
 			if err != nil {
 				t.Fatalf("expected no error when looking up persistent file for doc %q, got %v", d.ID, err)
 			}

--- a/persistence.go
+++ b/persistence.go
@@ -34,10 +34,7 @@ func persistToFile(filePath string, obj any, compress bool, encryptionKey string
 	return persistToFileWithCompression(filePath, obj, compressionFromBool(compress), encryptionKey)
 }
 
-// persistToFileWithCompression persists an object to a file at the given path.
-// The object is serialized as gob, optionally compressed with a registered codec
-// and optionally encrypted with AES-GCM. The encryption key must be 32 bytes
-// long. If the file exists, it's overwritten, otherwise created.
+// persistToFileWithCompression persists an object with a registered codec.
 func persistToFileWithCompression(filePath string, obj any, compression Compression, encryptionKey string) error {
 	if filePath == "" {
 		return fmt.Errorf("file path is empty")
@@ -87,10 +84,7 @@ func persistToWriter(w io.Writer, obj any, compress bool, encryptionKey string) 
 	return persistToWriterWithCompression(w, obj, compressionFromBool(compress), encryptionKey)
 }
 
-// persistToWriterWithCompression persists an object to a writer. The object is
-// serialized as gob, optionally compressed with a registered codec and
-// optionally encrypted with AES-GCM. The encryption key must be 32 bytes long.
-// If the writer has to be closed, it's the caller's responsibility.
+// persistToWriterWithCompression persists an object with a registered codec.
 func persistToWriterWithCompression(w io.Writer, obj any, compression Compression, encryptionKey string) error {
 	codec, ok := lookupCompressionCodec(compression)
 	if !ok {
@@ -128,10 +122,7 @@ func persistToWriterWithCompression(w io.Writer, obj any, compression Compressio
 		return fmt.Errorf("couldn't encode or write object: %w", err)
 	}
 
-	// Close the compressor so compression footers are written before encryption.
-	// When using encryption (and chainedWriter is a buffer) then we'll encrypt an
-	// incomplete stream. Without encryption when we return here and having a
-	// deferred Close(), there might be a silenced error.
+	// Close before encryption so compression footers are included.
 	if err := compressor.Close(); err != nil {
 		return fmt.Errorf("couldn't close compression writer: %w", err)
 	}

--- a/persistence.go
+++ b/persistence.go
@@ -2,7 +2,6 @@ package chromem
 
 import (
 	"bytes"
-	"compress/gzip"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -28,12 +27,23 @@ func hash2hex(name string) string {
 }
 
 // persistToFile persists an object to a file at the given path. The object is serialized
-// as gob, optionally compressed with flate (as gzip) and optionally encrypted with
+// as gob, optionally compressed with gzip and optionally encrypted with
 // AES-GCM. The encryption key must be 32 bytes long. If the file exists, it's
 // overwritten, otherwise created.
 func persistToFile(filePath string, obj any, compress bool, encryptionKey string) error {
+	return persistToFileWithCompression(filePath, obj, compressionFromBool(compress), encryptionKey)
+}
+
+// persistToFileWithCompression persists an object to a file at the given path.
+// The object is serialized as gob, optionally compressed with a registered codec
+// and optionally encrypted with AES-GCM. The encryption key must be 32 bytes
+// long. If the file exists, it's overwritten, otherwise created.
+func persistToFileWithCompression(filePath string, obj any, compression Compression, encryptionKey string) error {
 	if filePath == "" {
 		return fmt.Errorf("file path is empty")
+	}
+	if err := compression.validate(); err != nil {
+		return err
 	}
 	// AES 256 requires a 32 byte key
 	if encryptionKey != "" {
@@ -66,14 +76,26 @@ func persistToFile(filePath string, obj any, compress bool, encryptionKey string
 	}
 	defer f.Close()
 
-	return persistToWriter(f, obj, compress, encryptionKey)
+	return persistToWriterWithCompression(f, obj, compression, encryptionKey)
 }
 
 // persistToWriter persists an object to a writer. The object is serialized
-// as gob, optionally compressed with flate (as gzip) and optionally encrypted with
+// as gob, optionally compressed with gzip and optionally encrypted with
 // AES-GCM. The encryption key must be 32 bytes long.
 // If the writer has to be closed, it's the caller's responsibility.
 func persistToWriter(w io.Writer, obj any, compress bool, encryptionKey string) error {
+	return persistToWriterWithCompression(w, obj, compressionFromBool(compress), encryptionKey)
+}
+
+// persistToWriterWithCompression persists an object to a writer. The object is
+// serialized as gob, optionally compressed with a registered codec and
+// optionally encrypted with AES-GCM. The encryption key must be 32 bytes long.
+// If the writer has to be closed, it's the caller's responsibility.
+func persistToWriterWithCompression(w io.Writer, obj any, compression Compression, encryptionKey string) error {
+	codec, ok := lookupCompressionCodec(compression)
+	if !ok {
+		return fmt.Errorf("unsupported compression: %q", compression)
+	}
 	// AES 256 requires a 32 byte key
 	if encryptionKey != "" {
 		if len(encryptionKey) != 32 {
@@ -82,7 +104,7 @@ func persistToWriter(w io.Writer, obj any, compress bool, encryptionKey string) 
 	}
 
 	// We want to:
-	// Encode as gob -> compress with flate -> encrypt with AES-GCM -> write to
+	// Encode as gob -> compress -> encrypt with AES-GCM -> write to
 	// passed writer.
 	// To reduce memory usage we chain the writers instead of buffering, so we start
 	// from the end. For AES GCM sealing the stdlib doesn't provide a writer though.
@@ -94,29 +116,24 @@ func persistToWriter(w io.Writer, obj any, compress bool, encryptionKey string) 
 		chainedWriter = &bytes.Buffer{}
 	}
 
-	var gzw *gzip.Writer
-	var enc *gob.Encoder
-	if compress {
-		gzw = gzip.NewWriter(chainedWriter)
-		enc = gob.NewEncoder(gzw)
-	} else {
-		enc = gob.NewEncoder(chainedWriter)
+	compressor, err := codec.NewWriter(chainedWriter)
+	if err != nil {
+		return fmt.Errorf("couldn't create compression writer: %w", err)
 	}
+	enc := gob.NewEncoder(compressor)
 
 	// Start encoding, it will write to the chain of writers.
 	if err := enc.Encode(obj); err != nil {
+		_ = compressor.Close()
 		return fmt.Errorf("couldn't encode or write object: %w", err)
 	}
 
-	// If compressing, close the gzip writer. Otherwise, the gzip footer won't be
-	// written yet. When using encryption (and chainedWriter is a buffer) then
-	// we'll encrypt an incomplete stream. Without encryption when we return here and having
-	// a deferred Close(), there might be a silenced error.
-	if compress {
-		err := gzw.Close()
-		if err != nil {
-			return fmt.Errorf("couldn't close gzip writer: %w", err)
-		}
+	// Close the compressor so compression footers are written before encryption.
+	// When using encryption (and chainedWriter is a buffer) then we'll encrypt an
+	// incomplete stream. Without encryption when we return here and having a
+	// deferred Close(), there might be a silenced error.
+	if err := compressor.Close(); err != nil {
+		return fmt.Errorf("couldn't close compression writer: %w", err)
 	}
 
 	// Without encyrption, the chain is done and the writing is finished.
@@ -153,6 +170,10 @@ func persistToWriter(w io.Writer, obj any, compress bool, encryptionKey string) 
 // optionally be compressed as gzip and/or encrypted with AES-GCM. The encryption
 // key must be 32 bytes long.
 func readFromFile(filePath string, obj any, encryptionKey string) error {
+	return readFromFileWithCompression(filePath, obj, encryptionKey, "")
+}
+
+func readFromFileWithCompression(filePath string, obj any, encryptionKey string, compression Compression) error {
 	if filePath == "" {
 		return fmt.Errorf("file path is empty")
 	}
@@ -169,7 +190,7 @@ func readFromFile(filePath string, obj any, encryptionKey string) error {
 	}
 	defer r.Close()
 
-	return readFromReader(r, obj, encryptionKey)
+	return readFromReaderWithCompression(r, obj, encryptionKey, compression)
 }
 
 // readFromReader reads an object from a Reader. The object is deserialized from gob.
@@ -178,6 +199,10 @@ func readFromFile(filePath string, obj any, encryptionKey string) error {
 // be 32 bytes long.
 // If the reader has to be closed, it's the caller's responsibility.
 func readFromReader(r io.ReadSeeker, obj any, encryptionKey string) error {
+	return readFromReaderWithCompression(r, obj, encryptionKey, "")
+}
+
+func readFromReaderWithCompression(r io.ReadSeeker, obj any, encryptionKey string, compression Compression) error {
 	// AES 256 requires a 32 byte key
 	if encryptionKey != "" {
 		if len(encryptionKey) != 32 {
@@ -186,13 +211,13 @@ func readFromReader(r io.ReadSeeker, obj any, encryptionKey string) error {
 	}
 
 	// We want to:
-	// Read from reader -> decrypt with AES-GCM -> decompress with flate -> decode
+	// Read from reader -> decrypt with AES-GCM -> decompress -> decode
 	// as gob.
 	// To reduce memory usage we chain the readers instead of buffering, so we start
 	// from the end. For the decryption there's no reader though.
 
 	// For the chainedReader we don't declare it as ReadSeeker, so we can reassign
-	// the gzip reader to it.
+	// compression readers to it.
 	var chainedReader io.Reader
 
 	// Decrypt if an encryption key is provided
@@ -224,35 +249,34 @@ func readFromReader(r io.ReadSeeker, obj any, encryptionKey string) error {
 		chainedReader = r
 	}
 
-	// Determine if the stream is compressed
-	magicNumber := make([]byte, 2)
-	_, err := chainedReader.Read(magicNumber)
-	if err != nil {
-		return fmt.Errorf("couldn't read magic number to determine whether the stream is compressed: %w", err)
-	}
-	var compressed bool
-	if magicNumber[0] == 0x1f && magicNumber[1] == 0x8b {
-		compressed = true
-	}
+	var codec CompressionCodec
+	var ok bool
+	if compression == "" {
+		magicNumber := make([]byte, maxCompressionMagicLen())
+		n, err := io.ReadFull(chainedReader, magicNumber)
+		if err != nil && !(errors.Is(err, io.ErrUnexpectedEOF) && n > 0) {
+			return fmt.Errorf("couldn't read magic number to determine whether the stream is compressed: %w", err)
+		}
+		magicNumber = magicNumber[:n]
+		chainedReader = io.MultiReader(bytes.NewReader(magicNumber), chainedReader)
 
-	// Reset reader. Both the reader from the param and bytes.Reader support seeking.
-	if s, ok := chainedReader.(io.Seeker); !ok {
-		return fmt.Errorf("reader doesn't support seeking")
+		codec, compression, ok = detectCompressionCodec(magicNumber)
+		if !ok {
+			return fmt.Errorf("unsupported compression: %q", compression)
+		}
 	} else {
-		_, err := s.Seek(0, 0)
-		if err != nil {
-			return fmt.Errorf("couldn't reset reader: %w", err)
+		codec, ok = lookupCompressionCodec(compression)
+		if !ok {
+			return fmt.Errorf("unsupported compression: %q", compression)
 		}
 	}
 
-	if compressed {
-		gzr, err := gzip.NewReader(chainedReader)
-		if err != nil {
-			return fmt.Errorf("couldn't create gzip reader: %w", err)
-		}
-		defer gzr.Close()
-		chainedReader = gzr
+	compressionReader, err := codec.NewReader(chainedReader)
+	if err != nil {
+		return fmt.Errorf("couldn't create compression reader: %w", err)
 	}
+	defer compressionReader.Close()
+	chainedReader = compressionReader
 
 	dec := gob.NewDecoder(chainedReader)
 	err = dec.Decode(obj)


### PR DESCRIPTION
## Description

`chromem-go` currently hard-codes `gzip` as the only compression for persistence and export — `compress bool` toggles it on, magic-byte detection on read checks for `0x1f 0x8b` specifically, and the file extension is fixed to `.gz`

This PR introduces a small codec registry so callers can register their own compression _(zstd, lz4, brotli, etc.)_ without forking the library. `gzip` stays the default and the existing `compress bool` API keeps working unchanged

#### What changed

1. New `compression.go` with:
   - `Compression` string type and built-in `CompressionNone` / `CompressionGzip` codecs registered in `init()`
   - `CompressionCodec` struct describing a codec — `Extension`, `MagicNumber`, `NewWriter`, `NewReader`
   - `RegisterCompression(name, codec)` for external codecs. Reserved names _(`none`, `gzip`)_, duplicate names, duplicate extensions, and overlapping magic numbers all return errors so two codecs can't collide at read time
2. New `…WithCompression` variants of the existing methods:
   - `NewPersistentDBWithCompression`
   - `DB.ExportToFileWithCompression` / `DB.ExportToWriterWithCompression`
   - `DB.ImportFromFileWithCompression` / `DB.ImportFromReaderWithCompression`
3. The existing `compress bool` methods delegate to the new ones via `compressionFromBool(bool) Compression`, so callers don't need to change anything
4. Read-side auto-detection now scans all registered codecs' magic numbers — if a custom codec is registered with its magic bytes, files written with it are auto-detected on `Import` exactly like `gzip` is today. Callers can also pass an explicit `Compression` to skip detection
5. `Collection.getDocPath` now returns `(string, error)` because the extension comes from the codec — propagated through `AddDocument`, `Delete`, and the `Import` paths

#### Backwards compatibility

- The `compress bool` API _(`NewPersistentDB`, `ExportToFile`, etc.)_ is preserved and behaves identically — `true` selects `gzip`, `false` selects `none`
- On-disk format is unchanged for the built-in codecs — existing `.gob` and `.gob.gz` files load without modification
- The `DB.compress` / `Collection.compress` `bool` fields were internal and have been replaced with `compression Compression` — no public field rename

#### Tests

`compression_test.go` covers:
- Codec registration validation _(reserved names, duplicate names/extensions, overlapping magic numbers, missing constructors, malformed extensions)_
- Round-trip persist/read for a custom codec
- Auto-detection on read from magic bytes for a registered custom codec
- Compatibility with the existing `compress bool` paths

## Related Issue(s)