### PR TITLE
Make result fields a deep copy of the document fields

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -480,6 +480,9 @@ type Result struct {
 //     There can be fewer results if a filter is applied.
 //   - where: Conditional filtering on metadata. Optional.
 //   - whereDocument: Conditional filtering on documents. Optional.
+//
+// The [Result]'s [Document]-related fields are a deep copy of the original document's
+// fields, so they can be safely modified without affecting the collection.
 func (c *Collection) Query(ctx context.Context, queryText string, nResults int, where, whereDocument map[string]string) ([]Result, error) {
 	if queryText == "" {
 		return nil, errors.New("queryText is empty")
@@ -496,6 +499,9 @@ func (c *Collection) Query(ctx context.Context, queryText string, nResults int, 
 // QueryWithOptions performs an exhaustive nearest neighbor search on the collection.
 //
 //   - options: The options for the query. See [QueryOptions] for more information.
+//
+// The [Result]'s [Document]-related fields are a deep copy of the original document's
+// fields, so they can be safely modified without affecting the collection.
 func (c *Collection) QueryWithOptions(ctx context.Context, options QueryOptions) ([]Result, error) {
 	if options.QueryText == "" && len(options.QueryEmbedding) == 0 {
 		return nil, errors.New("QueryText and QueryEmbedding options are empty")
@@ -553,6 +559,9 @@ func (c *Collection) QueryWithOptions(ctx context.Context, options QueryOptions)
 //     There can be fewer results if a filter is applied.
 //   - where: Conditional filtering on metadata. Optional.
 //   - whereDocument: Conditional filtering on documents. Optional.
+//
+// The [Result]'s [Document]-related fields are a deep copy of the original document's
+// fields, so they can be safely modified without affecting the collection.
 func (c *Collection) QueryEmbedding(ctx context.Context, queryEmbedding []float32, nResults int, where, whereDocument map[string]string) ([]Result, error) {
 	return c.queryEmbedding(ctx, queryEmbedding, nil, 0, nResults, where, whereDocument)
 }
@@ -611,11 +620,12 @@ func (c *Collection) queryEmbedding(ctx context.Context, queryEmbedding, negativ
 
 	res := make([]Result, 0, len(nMaxDocs))
 	for i := 0; i < len(nMaxDocs); i++ {
+		doc := c.documents[nMaxDocs[i].docID]
 		res = append(res, Result{
 			ID:         nMaxDocs[i].docID,
-			Metadata:   c.documents[nMaxDocs[i].docID].Metadata,
-			Embedding:  c.documents[nMaxDocs[i].docID].Embedding,
-			Content:    c.documents[nMaxDocs[i].docID].Content,
+			Metadata:   maps.Clone(doc.Metadata),
+			Embedding:  slices.Clone(doc.Embedding),
+			Content:    doc.Content,
 			Similarity: nMaxDocs[i].similarity,
 		})
 	}

--- a/collection_test.go
+++ b/collection_test.go
@@ -584,6 +584,48 @@ func TestCollection_ListDocumentsPartial(t *testing.T) {
 	}
 }
 
+func TestCollection_QueryEmbeddingResultDeepCopiesDocumentFields(t *testing.T) {
+	ctx := context.Background()
+	db := NewDB()
+
+	c, err := db.CreateCollection("test", nil, nil)
+	if err != nil {
+		t.Fatal("expected no error, got", err)
+	}
+
+	vectors := []float32{-0.40824828, 0.40824828, 0.81649655} // normalized version of `{-0.1, 0.1, 0.2}`
+	if err := c.AddDocument(ctx, Document{
+		ID:        "1",
+		Metadata:  map[string]string{"foo": "bar"},
+		Embedding: vectors,
+		Content:   "hello world",
+	}); err != nil {
+		t.Fatalf("failed to add document: %v", err)
+	}
+
+	res, err := c.queryEmbedding(ctx, vectors, nil, 0, 1, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error from queryEmbedding: %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(res))
+	}
+
+	res[0].Metadata["foo"] = "mutated"
+	res[0].Embedding[0] = 0
+
+	doc, err := c.GetByID(ctx, "1")
+	if err != nil {
+		t.Fatalf("unexpected error getting document by ID: %v", err)
+	}
+	if doc.Metadata["foo"] != "bar" {
+		t.Fatalf("Result metadata mutation affected collection: expected %q, got %q", "bar", doc.Metadata["foo"])
+	}
+	if !slices.Equal(doc.Embedding, vectors) {
+		t.Fatalf("Result embedding mutation affected collection: expected %v, got %v", vectors, doc.Embedding)
+	}
+}
+
 func TestCollection_GetByID(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
Allow mutation of results without affecting the collection. This is in line with ListDocuments for example.

See https://github.com/philippgille/chromem-go/issues/128, but instead of following the suggestion to embed `Document` inside `Result`, it prevents the mutability of a collection through a result.